### PR TITLE
fix(ci): switch deploy trigger to tags (follow-up #1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: "Deploy: Heimdallr Service"
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v*.*.*' # Trigger on version tags like v1.0.0
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Refinement of the CI/CD pipeline: changed the deployment trigger from branch-push to semver tags (`v*`). This provides better control over production releases.

**Relates to:** #1
**Type:** FIX / BUILD