### PR TITLE
feat(api): implement graceful shutdown for server

### DIFF
--- a/cmd/heimdallr/main.go
+++ b/cmd/heimdallr/main.go
@@ -85,4 +85,11 @@ func main() {
 
 	<-stop
 	fmt.Println("\n✔ Shutting down gracefully...")
+
+  shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+  defer cancel()
+
+  if err := apiServer.Shutdown(shutdownCtx); err != nil {
+    log.Printf("Error during API server shutdown: %v", err)
+  }
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -61,4 +62,8 @@ func (s *Server) handleStats(c echo.Context) error {
 		return c.JSON(500, map[string]string{"error": "Failed to get stats"})
 	}
 	return c.JSON(200, stats)
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.router.Shutdown(ctx)
 }


### PR DESCRIPTION
## Summary
This PR introduces a graceful shutdown mechanism for the Echo API server. It ensures that active connections are handled properly before the process exits, preventing data loss or interrupted requests during deployments.

**Type:** FEAT / RELIABILITY

## Changes
- **API Layer**: Added `Shutdown(context.Context)` method to the `Server` struct.
- **Main Entrypoint**: Implemented a 10-second grace period using `context.WithTimeout` upon receiving `SIGTERM`/`SIGINT`.

## Technical Details
- Used `echo.Server.Shutdown` to orchestrate the closing of the HTTP listener.
- Managed resource cleanup within the `main` function's signal trap.

## Checklist (Definition of Done)
- [x] API server stops accepting new connections during shutdown.
- [x] Ongoing requests are given a 10s window to complete.
- [x] No goroutine leaks during the shutdown sequence.