### PR TITLE
feat(infra): grpc orchestration and dynamic xray handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,24 @@ R_PORT   := $(SERVER_TUNNEL_PORT)
 TEST_BINARY_NAME := heimdallr-test
 TEST_PORT        := 4000
 REMOTE_ENV_PATH  := /var/www/heimdallr/.env
+
+# --- Пути к прото файлам ---
+PROTO_DIR := ./api/proto
+PROTO_OUT := ./internal/xray/proto
+
+# --- Proto toolchain ---
+PROTOC        ?= protoc
+PROTO_SRC_DIR := ./api/proto
+PROTO_GEN_DIR := ./internal/xray/proto
+PROTO_STAMP   := $(PROTO_GEN_DIR)/.stamp
+
+PROTO_FILES := \
+    $(PROTO_SRC_DIR)/app/proxyman/command/command.proto \
+    $(PROTO_SRC_DIR)/app/proxyman/config.proto
+
+PROTO_DEPS := \
+    $(shell find $(PROTO_SRC_DIR) -type f -name '*.proto' 2>/dev/null)
+
 # 1. Сначала пытаемся взять из .env (уже сделано через include)
 # 2. Если переменная пустая или не задана, устанавливаем фолбек
 ifeq ($(LOCAL_STATIC_DIR),)
@@ -43,8 +61,9 @@ GO_BUILD_FLAGS := CGO_ENABLED=0 go build -trimpath -ldflags="-s -w"
 NPM_INSTALL_FLAGS := --ignore-scripts --include=dev
 
 # .PHONY сообщает make, что это команды, а не названия файлов на диске
-.PHONY: help build ui-build ui-install go-build dev dev-ui tunnel stop clean db-reset \
-        prod-check deploy-test stop-test tunnel-test setup
+.PHONY: help build ui-build ui-install go-build go-deps dev dev-ui tunnel stop clean db-reset \
+        prod-check deploy-test stop-test tunnel-test setup \
+		proto proto-check proto-clean proto-verify test-backend test-race
 
 # Команда по умолчанию
 all: build
@@ -82,6 +101,37 @@ dev-ui: ## Запустить dev-сервер фронтенда
 	npm run dev -w web/ui
 
 # ==============================================================================
+# PROTOBUF / GRPC CODEGEN
+# ==============================================================================
+
+proto-check: ## Проверить наличие protoc и go-плагинов
+	@command -v $(PROTOC) >/dev/null || (echo "ERROR: protoc not found"; exit 1)
+	@command -v protoc-gen-go >/dev/null || (echo "ERROR: protoc-gen-go not found"; exit 1)
+	@command -v protoc-gen-go-grpc >/dev/null || (echo "ERROR: protoc-gen-go-grpc not found"; exit 1)
+	@test -d "$(PROTO_SRC_DIR)" || (echo "ERROR: $(PROTO_SRC_DIR) not found"; exit 1)
+
+$(PROTO_STAMP): $(PROTO_DEPS) proto-check
+	@echo "--- [PROTO] Generating Go stubs ---"
+	@mkdir -p $(PROTO_GEN_DIR)
+	@$(PROTOC) -I $(PROTO_SRC_DIR) \
+		--go_out=$(PROTO_GEN_DIR) --go_opt=paths=source_relative \
+		--go-grpc_out=$(PROTO_GEN_DIR) --go-grpc_opt=paths=source_relative \
+		$(PROTO_FILES)
+	@touch $(PROTO_STAMP)
+	@echo "✔ Proto generated"
+
+proto: $(PROTO_STAMP) ## Сгенерировать protobuf/gRPC код
+
+proto-clean: ## Очистить сгенерированные proto-файлы
+	@rm -rf $(PROTO_GEN_DIR)
+	@echo "✔ Proto artifacts removed"
+
+proto-verify: proto ## Проверить, что сгенерированный код закоммичен (для CI)
+	@git diff --quiet -- $(PROTO_GEN_DIR) || \
+		(echo "ERROR: generated proto code is out of date. Run 'make proto' and commit changes."; exit 1)
+	@echo "✔ Proto code is up-to-date"
+
+# ==============================================================================
 # BACKEND (GO)
 # ==============================================================================
 
@@ -92,6 +142,15 @@ go-deps: ## Синхронизировать зависимости Go
 go-build: go-deps ## Собрать только Go бинарник
 	@echo "--- [GO] Building binary ---"
 	$(GO_BUILD_FLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) $(GO_PKG)
+
+test-backend: ## Прогнать backend тесты (без frontend)
+	@echo "--- [TEST] Running backend tests ---"
+	go test ./cmd/... ./internal/...
+
+test-race: ## Прогнать backend тесты с race detector
+	@echo "--- [TEST] Running backend race tests ---"
+	go test -race ./cmd/... ./internal/...
+
 
 # ==============================================================================
 # КОМБИНИРОВАННЫЕ КОМАНДЫ (DEVELOPMENT & PROD)

--- a/internal/xray/stats.go
+++ b/internal/xray/stats.go
@@ -3,10 +3,15 @@ package xray
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/ZeroD1vision/heimdallr-proxy/internal/models"
-	"github.com/xtls/xray-core/app/stats/command"
+	hsc "github.com/xtls/xray-core/app/proxyman/command" // hsc = Handler Service Command
+	ssc "github.com/xtls/xray-core/app/stats/command"    // ssc = Stats Service Command
+	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/common/serial"
+	vless "github.com/xtls/xray-core/proxy/vless"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
@@ -15,8 +20,11 @@ import (
 // Client — низкоуровневый gRPC клиент к Xray Stats API.
 // Не логирует — только возвращает ошибки. Логирование на стороне вызывающего кода.
 type Client struct {
-	apiAddr string
-	conn    *grpc.ClientConn
+	apiAddr       string
+	conn          *grpc.ClientConn
+	statsClient   ssc.StatsServiceClient
+	handlerClient hsc.HandlerServiceClient
+	mu            sync.Mutex
 }
 
 // NewClient создаёт клиент. При ошибке соединения не падает — Xray может
@@ -34,7 +42,12 @@ func NewClient(addr string) (*Client, error) {
 		return &Client{apiAddr: addr, conn: nil}, fmt.Errorf("initial grpc dial %s: %w", addr, err)
 	}
 
-	return &Client{apiAddr: addr, conn: conn}, nil
+	return &Client{
+		apiAddr:       addr,
+		conn:          conn,
+		statsClient:   ssc.NewStatsServiceClient(conn),
+		handlerClient: hsc.NewHandlerServiceClient(conn),
+	}, nil
 }
 
 // GetUserStats получает статистику трафика для конкретного пользователя по email.
@@ -44,10 +57,8 @@ func (c *Client) GetUserStats(ctx context.Context, email string) (models.UserSta
 		return models.UserStats{}, err
 	}
 
-	client := command.NewStatsServiceClient(c.conn)
-
 	// Xray Stats API: паттерн "user>>>EMAIL>>>traffic" возвращает uplink + downlink.
-	req := &command.QueryStatsRequest{
+	req := &ssc.QueryStatsRequest{
 		Pattern: fmt.Sprintf("user>>>%s>>>traffic", email),
 		Reset_:  false,
 	}
@@ -56,7 +67,7 @@ func (c *Client) GetUserStats(ctx context.Context, email string) (models.UserSta
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	res, err := client.QueryStats(queryCtx, req)
+	res, err := c.statsClient.QueryStats(queryCtx, req)
 	if err != nil {
 		return models.UserStats{}, fmt.Errorf("query xray stats for %s: %w", email, err)
 	}
@@ -81,8 +92,82 @@ func (c *Client) GetUserStats(ctx context.Context, email string) (models.UserSta
 	}, nil
 }
 
+// AddUser добавляет пользователя в указанный inbound через HandlerService.
+func (c *Client) AddUser(ctx context.Context, user models.User) error {
+	if err := c.ensureConnected(); err != nil {
+		return err
+	}
+
+	if user.Email == "" {
+		return fmt.Errorf("email must not be empty")
+	}
+	if user.UUID == "" {
+		return fmt.Errorf("uuid must not be empty")
+	}
+	if user.InboundTag == "" {
+		return fmt.Errorf("inbound tag must not be empty")
+	}
+
+	account := &vless.Account{
+		Id:         user.UUID,
+		Flow:       user.VlessFlow,
+		Encryption: "none",
+	}
+
+	operation := serial.ToTypedMessage(&hsc.AddUserOperation{
+		User: &protocol.User{
+			Email:   user.Email,
+			Level:   0,
+			Account: serial.ToTypedMessage(account),
+		},
+	})
+
+	callCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := c.handlerClient.AlterInbound(callCtx, &hsc.AlterInboundRequest{
+		Tag:       user.InboundTag,
+		Operation: operation,
+	})
+	if err != nil {
+		return fmt.Errorf("xray add user %s on inbound %s: %w", user.Email, user.InboundTag, err)
+	}
+
+	return nil
+}
+
+// RemoveUser удаляет пользователя из указанного inbound по email.
+func (c *Client) RemoveUser(ctx context.Context, inboundTag, email string) error {
+	if err := c.ensureConnected(); err != nil {
+		return err
+	}
+	if inboundTag == "" {
+		return fmt.Errorf("inbound tag must not be empty")
+	}
+	if email == "" {
+		return fmt.Errorf("email must not be empty")
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := c.handlerClient.AlterInbound(callCtx, &hsc.AlterInboundRequest{
+		Tag: inboundTag,
+		Operation: serial.ToTypedMessage(&hsc.RemoveUserOperation{
+			Email: email,
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("xray remove user %s from inbound %s: %w", email, inboundTag, err)
+	}
+
+	return nil
+}
+
 // Close закрывает gRPC соединение. Вызывать при graceful shutdown.
 func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.conn != nil {
 		return c.conn.Close()
 	}
@@ -92,15 +177,38 @@ func (c *Client) Close() error {
 // ensureConnected проверяет соединение и переподключается если нужно.
 // Выделено в отдельный метод чтобы не засорять GetUserStats.
 func (c *Client) ensureConnected() error {
-	if c.conn != nil && c.conn.GetState() != connectivity.Shutdown {
-		return nil
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.conn != nil {
+		state := c.conn.GetState()
+		if state != connectivity.Shutdown {
+			return nil
+		}
+		_ = c.conn.Close()
+		c.conn = nil
 	}
 
-	conn, err := grpc.NewClient(c.apiAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return fmt.Errorf("reconnect to xray api at %s: %w", c.apiAddr, err)
+	baseDelay := 200 * time.Millisecond
+	maxAttempts := 5
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		conn, err := grpc.NewClient(c.apiAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err == nil {
+			c.conn = conn
+			c.statsClient = ssc.NewStatsServiceClient(conn)
+			c.handlerClient = hsc.NewHandlerServiceClient(conn)
+			return nil
+		}
+		lastErr = err
+
+		delay := baseDelay << attempt
+		if delay > 3*time.Second {
+			delay = 3 * time.Second
+		}
+		time.Sleep(delay)
 	}
 
-	c.conn = conn
-	return nil
+	return fmt.Errorf("reconnect to xray api at %s failed after %d attempts: %w", c.apiAddr, maxAttempts, lastErr)
 }


### PR DESCRIPTION
## Summary
Linked Issue: #42, #37

Integrated gRPC HandlerService to allow dynamic Xray reconfiguration without process restarts. Implemented a robust Makefile-driven protobuf generation pipeline with automated dependency checks.

## Type of Change
- [x] FEAT: Xray HandlerService integration
- [x] BUILD: Makefile protoc orchestration
- [x] DX: Protobuf code generation tooling

## Verification Results
### Manual Verification
Verified that `internal/xray/proto` contains valid Go stubs and the backend initializes both Stats and Handler clients.

Closes #42, #37