### PR TITLE
feat(db): extended user models for vless/reality support

### DIFF
--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ZeroD1vision/heimdallr-proxy/internal/models"
 	"gorm.io/gorm"
@@ -61,6 +62,53 @@ func (s *Store) UpdateUser(ctx context.Context, user *models.User) error {
 	err := s.db.WithContext(ctx).Save(user).Error
 	if err != nil {
 		return fmt.Errorf("update user %s: %w", user.Email, err)
+	}
+	return nil
+}
+
+func (s *Store) DeleteUser(ctx context.Context, email string) error {
+	result := s.db.WithContext(ctx).Where("email = ?", email).Delete(&models.User{})
+	if result.Error != nil {
+		return fmt.Errorf("delete user %s: %w", email, result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpdateStatus обновляет статус блокировки и дату истечения доступа.
+func (s *Store) UpdateStatus(ctx context.Context, email string, isBlocked bool, expiresAt *time.Time) error {
+	user := models.User{
+		IsBlocked: isBlocked,
+		ExpiresAt: expiresAt,
+	}
+
+	result := s.db.WithContext(ctx).
+		Model(&models.User{}).
+		Where("email = ?", email).
+		Select("is_blocked", "expires_at").
+		Updates(&user)
+	if result.Error != nil {
+		return fmt.Errorf("update user status %s: %w", email, result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ResetTraffic сбрасывает лимит трафика пользователя (0 = без лимита).
+func (s *Store) ResetTraffic(ctx context.Context, email string) error {
+	result := s.db.WithContext(ctx).
+		Model(&models.User{}).
+		Where("email = ?", email).
+		Update("traffic_limit", 0)
+	if result.Error != nil {
+		return fmt.Errorf("reset traffic for %s: %w", email, result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
 	}
 	return nil
 }

--- a/internal/models/stats.go
+++ b/internal/models/stats.go
@@ -36,18 +36,6 @@ type UserHistory struct {
 	CreatedAt time.Time `json:"created_at"  gorm:"index;not null"`
 }
 
-// User — учётная запись клиента.
-// Центральная модель: связывает email (идентификатор в Xray),
-// Telegram ID (для 2FA и бота) и UUID (для VLESS конфига).
-type User struct {
-	ID           uint   `json:"id"            gorm:"primaryKey"`
-	Email        string `json:"email"         gorm:"uniqueIndex;not null"`
-	TelegramID   int64  `json:"telegram_id"   gorm:"uniqueIndex"`
-	XrayUUID     string `json:"xray_uuid"     gorm:"uniqueIndex;not null"`
-	TrafficLimit int64  `json:"traffic_limit"` // байты, 0 = без лимита
-	State        string `json:"state"         gorm:"default:'active'"` // active | blocked | pending
-}
-
 // OTPCode — одноразовый код для 2FA.
 // TTL контролируется полем ExpiresAt — фоновая чистка удаляет просроченные записи.
 // Один активный код на пользователя — при запросе нового старый перезаписывается.

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -1,0 +1,44 @@
+package models
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// User — учётная запись клиента для управления доступом в Xray.
+// UUID генерируется автоматически на стороне бэкенда (BeforeCreate),
+// чтобы исключить доверие к внешнему вводу.
+type User struct {
+	ID           uint       `json:"id"             gorm:"primaryKey"`
+	Email        string     `json:"email"          gorm:"uniqueIndex;not null"`
+	TelegramID   int64      `json:"telegram_id"    gorm:"uniqueIndex"`
+	UUID         string     `json:"uuid"           gorm:"uniqueIndex;not null"`
+	InboundTag   string     `json:"inbound_tag"    gorm:"index;not null;default:'inbound-main'"`
+	Flow         string     `json:"flow"           gorm:"default:''"`
+	VlessFlow    string     `json:"vless_flow"     gorm:"default:''"`
+	TrafficLimit int64      `json:"traffic_limit"`
+	IsBlocked    bool       `json:"is_blocked"     gorm:"index;default:false"`
+	ExpiresAt    *time.Time `json:"expires_at"     gorm:"index"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+}
+
+// BeforeCreate гарантирует RFC4122 UUID до вставки записи в БД.
+func (u *User) BeforeCreate(_ *gorm.DB) error {
+	if u.Email == "" {
+		return fmt.Errorf("user email must not be empty")
+	}
+	if u.UUID == "" {
+		u.UUID = uuid.NewString()
+	}
+	if _, err := uuid.Parse(u.UUID); err != nil {
+		return fmt.Errorf("invalid uuid format: %w", err)
+	}
+	if u.InboundTag == "" {
+		u.InboundTag = "inbound-main"
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
Linked Issue: #43

Expanded the core User model to support VLESS/Reality metadata, including UUIDs and InboundTags. Implemented GORM hooks for secure UUID generation and added administrative DB methods for user lifecycle management.

## Type of Change
- [x] FEAT: Extended User schema
- [x] REFACTOR: Centralized User model
- [x] CHORE: Database migration update

## Verification Results

### Manual Verification
Verified that `BeforeCreate` hook generates valid RFC4122 UUIDs during user insertion.

Closes #43