### PR TITLE
feat(logic): active traffic enforcement and admin alerting

### DIFF
--- a/cmd/heimdallr/main.go
+++ b/cmd/heimdallr/main.go
@@ -88,24 +88,7 @@ func main() {
 	checkCancel()
 
 	// -------------------------------------------------------------------------
-	// 5. Воркеры — Pipeline для асинхронной обработки пользователей
-	// -------------------------------------------------------------------------
-	// Bouncer реализует логику работы с пользователями в Xray (DB + в будущем Xray)
-	bouncer := collector.NewBouncer(store)
-	// Pipeline управляет очередью задач и многопоточным выполнением
-	enforcePipeline := collector.NewPipeline(bouncer, 3) // 3 воркера
-
-	// -------------------------------------------------------------------------
-	// 6. Коллектор — фоновый сбор статистики в БД
-	// -------------------------------------------------------------------------
-	statsCollector := collector.NewCollector(store, xrayClient, enforcePipeline, cfg.collectInterval)
-
-	collectorCtx, collectorCancel := context.WithCancel(context.Background())
-	defer collectorCancel()
-
-	
-	// -------------------------------------------------------------------------
-	// 7. Telegram бот
+	// 5. Telegram бот
 	// -------------------------------------------------------------------------
 	// xrayClient реализует bot.StatsProvider — есть метод GetUserStats.
 	tgBot, err := bot.NewBot(xrayClient, cfg.adminEmail)
@@ -114,6 +97,22 @@ func main() {
 		os.Exit(1)
 	}
 	
+	// -------------------------------------------------------------------------
+	// 6. Воркеры — Pipeline для асинхронной обработки пользователей
+	// -------------------------------------------------------------------------
+	// Bouncer реализует логику работы с пользователями в Xray (DB + в будущем Xray)
+	bouncer := collector.NewBouncer(store, xrayClient, tgBot)
+	// Pipeline управляет очередью задач и многопоточным выполнением
+	enforcePipeline := collector.NewPipeline(bouncer, 3) // 3 воркера
+
+	// -------------------------------------------------------------------------
+	// 7. Коллектор — фоновый сбор статистики в БД
+	// -------------------------------------------------------------------------
+	statsCollector := collector.NewCollector(store, xrayClient, enforcePipeline, cfg.collectInterval)
+
+	collectorCtx, collectorCancel := context.WithCancel(context.Background())
+	defer collectorCancel()
+
 	// -------------------------------------------------------------------------
 	// 8. API сервер
 	// -------------------------------------------------------------------------

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -71,6 +71,15 @@ func (b *Bot) SendOTP(ctx context.Context, telegramID int64, code string) error 
 	return nil
 }
 
+// SendAlert отправляет техническое уведомление администратору.
+func (b *Bot) SendAlert(ctx context.Context, text string) error {
+	recipient := &telebot.User{ID: b.AdminID}
+	if _, err := b.Api.Send(recipient, text); err != nil {
+		return fmt.Errorf("send alert to admin %d: %w", b.AdminID, err)
+	}
+	return nil
+}
+
 func (b *Bot) handleStart(c telebot.Context) error {
 	slog.Info("bot command received", "command", "/start", "user_id", c.Sender().ID)
 	return c.Send("Welcome to Heimdallr Proxy!")

--- a/internal/collector/bouncer.go
+++ b/internal/collector/bouncer.go
@@ -4,36 +4,54 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/ZeroD1vision/heimdallr-proxy/internal/models"
 )
 
 // EnforcerStore описывает методы БД, нужные для блокировки
 type EnforcerStore interface {
-	UpdateUser(ctx context.Context, user *models.User) error
+	UpdateStatus(ctx context.Context, email string, isBlocked bool, expiresAt *time.Time) error
+}
+
+type EnforcerXray interface {
+	RemoveUser(ctx context.Context, inboundTag, email string) error
+}
+
+type AlertNotifier interface {
+	SendAlert(ctx context.Context, text string) error
 }
 
 type Bouncer struct {
-	store EnforcerStore
-	// Здесь позже появится xrayClient для gRPC вызовов
+	store    EnforcerStore
+	xray     EnforcerXray
+	notifier AlertNotifier
 }
 
 // ВЫШЫБАЛА - отвечает за блокировку юзера в БД и отключение его от Xray.
-func NewBouncer(store EnforcerStore) *Bouncer {
-	return &Bouncer{store: store}
+func NewBouncer(store EnforcerStore, xray EnforcerXray, notifier AlertNotifier) *Bouncer {
+	return &Bouncer{store: store, xray: xray, notifier: notifier}
 }
 
 func (b *Bouncer) BlockUser(ctx context.Context, user models.User) error {
 	slog.Warn("BOUNCER: blocking user", "email", user.Email)
 
 	// 1. Меняем статус в базе данных
-	user.State = "blocked"
-	if err := b.store.UpdateUser(ctx, &user); err != nil {
+	if err := b.store.UpdateStatus(ctx, user.Email, true, user.ExpiresAt); err != nil {
 		return fmt.Errorf("db update failed: %w", err)
 	}
 
-	// 2. TODO: Здесь будет вызов gRPC к Xray, чтобы реально отключить юзера
-	// b.xray.RemoveUser(ctx, user.Email)
+	// 2. Удаляем пользователя из inbound в Xray.
+	if err := b.xray.RemoveUser(ctx, user.InboundTag, user.Email); err != nil {
+		return fmt.Errorf("xray remove failed: %w", err)
+	}
+
+	if b.notifier != nil {
+		msg := fmt.Sprintf("🚨 Пользователь %s автоматически заблокирован: превышен лимит трафика", user.Email)
+		if err := b.notifier.SendAlert(ctx, msg); err != nil {
+			slog.Error("failed to send block alert", "email", user.Email, "error", err)
+		}
+	}
 
 	slog.Info("BOUNCER: user successfully blocked", "email", user.Email)
 	return nil

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -74,9 +74,9 @@ func (c *Collector) tick(ctx context.Context) {
 
 	for _, user := range users {
 		// Пропускаем уже заблокированных
-        if user.State == "blocked" {
-            continue
-        }
+		if user.IsBlocked {
+			continue
+		}
 
 		stats, err := c.xray.GetUserStats(ctx, user.Email)
 		if err != nil {
@@ -86,10 +86,10 @@ func (c *Collector) tick(ctx context.Context) {
 		}
 
 		// Лимит: Downlink + Uplink
-        if user.TrafficLimit > 0 && (stats.Downlink + stats.Uplink) > user.TrafficLimit {
-            slog.Warn("limit exceeded, submitting to pipeline", "email", user.Email)
-            c.pipeline.Submit(user)
-        }
+		if user.TrafficLimit > 0 && (stats.Downlink+stats.Uplink) > user.TrafficLimit {
+			slog.Warn("limit exceeded, submitting to pipeline", "email", user.Email)
+			c.pipeline.Submit(user)
+		}
 
 		history := &models.UserHistory{
 			Email:     stats.Email,


### PR DESCRIPTION
## Summary
Linked Issue: #38

Transformed the Bouncer into an active enforcer. The pipeline now triggers physical removal from Xray-core via gRPC and notifies the administrator through Telegram when traffic limits are exceeded.

## Type of Change
- [x] FEAT: Active gRPC enforcement
- [x] FEAT: Telegram admin alerts
- [x] REFACTOR: Non-blocking enforcement pipeline

## Verification Results
### Manual Verification
Simulated traffic limit exceedance. Verified logs: User marked as blocked in DB -> Removed from Xray via gRPC -> Alert received in Telegram.

Closes #38