### PR TITLE
build(infra): upgrade frontend toolchain and automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 # Подгружаем переменные окружения
 ifneq (,$(wildcard ./.env))
     include .env
+	export $(shell sed 's/=.*//' .env)
 endif
 
 # --- Константы путей ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -4125,6 +4125,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5494,6 +5521,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.9.0.tgz",
+      "integrity": "sha512-6qVAmbgCjcJz7sAGSPSSJ++RAwjlK2XCbRrZKv63Ciko1KT8jX0//CXxgI3jg2HlJu8tADqdYlNDebmYjeoruA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5589,6 +5625,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8059,6 +8110,8 @@
       "name": "heimdallr-ui",
       "version": "1.0.0",
       "dependencies": {
+        "framer-motion": "^12.38.0",
+        "lucide-react": "^1.9.0",
         "next": "^16.2.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -10,6 +10,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "framer-motion": "^12.38.0",
+    "lucide-react": "^1.9.0",
     "next": "^16.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
## Summary

Standardized the frontend build environment and integrated core UI libraries. Updated Makefile to support direct .env export for local development and shadow deploys.

## Type of Change
- [x] BUILD: Changes affecting build system or dependencies
- [x] CHORE: Makefile env management

## Verification Results
### Manual Verification
Confirmed `make run-ui` correctly picks up variables. Verified `package-lock.json` integrity after installing Framer Motion.