### PR TITLE
feat/api driven scene media loading

### DIFF
--- a/web/ui/src/app/(auth)/login/page.tsx
+++ b/web/ui/src/app/(auth)/login/page.tsx
@@ -5,8 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 import { useVisualStore } from '@/store/use-visual-store';
 import { authApi, tokenStorage } from '@/lib/api';
-import { DigitBox } from '@/components/auth/digit-box';
-import { GlassPane, GlassPaneContent } from '@/components/ui/glass-pane';
+import { DigitBox, AuthCard, AuthButton } from '@/components/auth';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -48,38 +47,6 @@ const fadeScale = {
   exit:       { opacity: 0, scale: 1.03 },
   transition: { duration: 0.25, ease: 'easeOut' as const },
 };
-
-// ── AuthCard ──────────────────────────────────────────────────────────────────
-
-/**
- * AuthCard — стеклянная карточка по паттерну из navbar:
- *
- *   Слой 1 (z-0): GlassPane        — абсолютная подложка с мягким блюром, border, тень.
- *                                     Это "шторка" — она знает, что она absolute.
- *   Слой 2 (z-10): GlassPaneContent — relative-обёртка для контента поверх шторки,
- *                                     дополнительно усиленная backdrop-blur-3xl —
- *                                     ровно как центральное меню в navbar лежит
- *                                     поверх GlassPane с более сильным блюром.
- */
-function AuthCard({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="relative">
-      <div className="absolute -inset-0.5 bg-white/5 blur-2xl opacity-20 group-hover:opacity-30 transition duration-1000" />
-      {/* Фоновая шторка */}
-      <GlassPane 
-        className="inset-0 shadow-2xl" 
-        style={{ 
-          borderRadius: '24px',
-          backgroundColor: 'rgba(0, 0, 0, 0.4)'
-        }} 
-      />
-      {/* Контентный слой */}
-      <GlassPaneContent className="relative z-10">
-        {children}
-      </GlassPaneContent>
-    </div>
-  );
-}
 
 function FloatingInput({ 
   label, 
@@ -169,37 +136,25 @@ export default function LoginPage() {
 
   // ── Visual store — управление фоновой сценой ──────────────────────────────
 
+  // При монтировании устанавливаем сцену на 'auth' и пытаемся запустить видео.
   useEffect(() => {
     // Если уже есть токен — нечего тут делать
     if (tokenStorage.getToken()) {
-      router.replace('/auth/profile');
+      router.replace('/profile');
       return;
     }
-
     const store = useVisualStore.getState();
-    store.setScene('auth');
-    store.videoElements.data?.play().catch(() => {});
+    store.setScene('auth');  // Установка сцены для фонового видео
 
-    // Переключаем видео когда ресурс загрузится
-    const unsub = useVisualStore.subscribe(
-      (s) => s.loadingStage,
-      (stage) => {
-        if (stage === 'ready') {
-          useVisualStore.getState().videoElements.data?.play().catch(() => {});
-          unsub();
-        }
-      }
-    );
-
+    // По выходу после ререндеринга сбрасываем сцену на лендинг
     return () => {
-      unsub();
-      useVisualStore.getState().setScene('landing');
+      store.setScene('landing');
     };
   }, []);
 
   // ── State ─────────────────────────────────────────────────────────────────
 
-  const [step,      setStep     ] = useState<Step>('input');
+  const [step,      setStep     ] = useState<Step>('input'); // текущий шаг авторизации
   const [email,     setEmail    ] = useState('');
   const [password,  setPassword ] = useState('');
   const [tgLink,    setTgLink   ] = useState('');
@@ -428,16 +383,9 @@ export default function LoginPage() {
                     )}
                   </AnimatePresence>
                   
-                  <button
-                    type="submit"
-                    disabled={isLoading || !email || !password}
-                    className="w-full bg-white text-black font-syne font-black text-[11px]
-                      uppercase tracking-[0.3em] py-5 rounded-2xl mt-4
-                      hover:bg-zinc-200 transition-all duration-300
-                      disabled:opacity-20 shadow-[0_0_20px_rgba(255,255,255,0.1)]"
-                  >
-                    {isLoading ? 'Initializing...' : 'Initialize Entity'}
-                  </button>
+                  <AuthButton isLoading={isLoading} disabled={isLoading || !email || !password}>
+                    Initialize Entity
+                  </AuthButton>
                 </form>
               </div>
             </AuthCard>

--- a/web/ui/src/app/(auth)/register/page.tsx
+++ b/web/ui/src/app/(auth)/register/page.tsx
@@ -5,8 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 import { useVisualStore } from '@/store/use-visual-store';
 import { authApi, tokenStorage } from '@/lib/api';
-import { AuthLayout, AuthCard, AuthButton } from '@/components/auth/auth-layout';
-import { FloatingInput } from '@/components/auth/floating-input';
+import { AuthCard, AuthButton, FloatingInput } from '@/components/auth';
 
 type RegisterStep = 'input' | 'awaiting_link' | 'success';
 
@@ -19,14 +18,23 @@ export default function RegisterPage() {
   const [tgLink, setTgLink] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
-  // Инициализация визуальной сцены (фон, видео)
+  // При монтировании устанавливаем сцену на 'auth' и пытаемся запустить видео.
   useEffect(() => {
+    // Если уже есть токен — нечего тут делать
+    if (tokenStorage.getToken()) {
+      router.replace('/profile');
+      return;
+    }
     const store = useVisualStore.getState();
     store.setScene('auth');
-    return () => store.setScene('landing');
+    // По выходу после ререндеринга сбрасываем сцену на лендинг
+    return () => {
+      store.setScene('landing');
+    };
   }, []);
 
-  // МАГИЯ: Поллинг статуса регистрации
+  // МАГИЯ для удобства пользователя: Поллинг статуса регистрации
+  // (но думаю это уязвимость для ботов сканеров)
   useEffect(() => {
     if (step !== 'awaiting_link' || !sessionId) return;
 
@@ -48,11 +56,12 @@ export default function RegisterPage() {
     return () => clearInterval(interval);
   }, [step, sessionId, router]);
 
+  // Обработчик отправки формы регистрации
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
     try {
-      const res = await authApi.register(email, password);
+      const res = await authApi.register(email, password); // Запрос в API на регистрацию
       if (res.session_id && res.tg_link) {
         setSessionId(res.session_id);
         setTgLink(res.tg_link);

--- a/web/ui/src/app/page.tsx
+++ b/web/ui/src/app/page.tsx
@@ -14,21 +14,15 @@
  *   Все кадры грузятся параллельно на mount через Promise.all.
  *   Пока грузятся — canvas показывает анимированную заглушку.
  *   Когда загрузились — переключаемся на кадры.
+ * 
+ * TODO: Оптимизировать загрузку, 
  */
 
 import { useEffect, useRef, useCallback, useState } from 'react';
-import Link from 'next/link';
-import { motion } from 'framer-motion';
-import { initGlobalLoading } from '@/lib/visual-orchestrator';
 import { useVisualStore } from '@/store/use-visual-store';
 
 // ── Конфиг кадров ─────────────────────────────────────────────────────────────
-const HERO_FRAMES = 121;
 const TRANSITION_FRAMES = 192;
-const DATA_FRAMES = 192;
-
-const framePath = (section: 'hero' | 'transition' | 'data', n: number) =>
-  `/assets/frames/${section}/frame_${String(n).padStart(4, '0')}.jpg`;
 
 // ── Scroll зоны ───────────────────────────────────────────────────────────────
 const HERO_VH = 1.0;
@@ -87,16 +81,6 @@ export default function LandingPage() {
   const heroUIRef = useRef<HTMLDivElement>(null);
   const dataUIRef = useRef<HTMLDivElement>(null);
 
-  // Загруженные кадры
-  const heroFrames = useRef<HTMLImageElement[]>([]);
-  const transFrames = useRef<HTMLImageElement[]>([]);
-  const dataFrames = useRef<HTMLImageElement[]>([]);
-  const framesReady = useRef(false);
-
-  // Прогресс загрузки для индикатора
-  // const [loadProgress, setLoadProgress] = useState(0);
-  // const [loaded, setLoaded] = useState(false);
-
   const loadProgress = useVisualStore((s) => s.loadProgress);
   const loaded = useVisualStore((s) => s.loadingStage === 'ready');
 
@@ -119,6 +103,10 @@ export default function LandingPage() {
   const lastT = useRef(0);
   const pts = useRef<Particle[]>([]);
   const geo = useRef({ W: 0, H: 0, heroHold: 0, transLen: 0 });
+  
+  // Кешируем градиент и состояние стора
+  const cachedGradient = useRef<CanvasGradient | null>(null);
+  const cachedStoreState = useRef<ReturnType<typeof useVisualStore.getState> | null>(null);
 
   // ── Setup ──────────────────────────────────────────────────────────────────
   const setup = useCallback(() => {
@@ -134,6 +122,9 @@ export default function LandingPage() {
       c.width = W;
       c.height = H;
     }
+    // Очищаем кеш градиента при resize
+    cachedGradient.current = null;
+    
     const p: Particle[] = [];
     for (let i = 0; i < 280; i++)
       p.push({
@@ -147,57 +138,6 @@ export default function LandingPage() {
       });
     pts.current = p;
   }, []);
-
-  // ── Загрузка кадров ────────────────────────────────────────────────────────
-  // const loadFrames = useCallback(async () => {
-  //   const total = HERO_FRAMES + TRANSITION_FRAMES + DATA_FRAMES;
-  //   let done = 0;
-
-  //   const load = (src: string): Promise<HTMLImageElement> =>
-  //     new Promise((res) => {
-  //       const img = new Image();
-  //       img.onload = () => {
-  //         done++;
-  //         setLoadProgress(Math.round((done / total) * 100));
-  //         res(img);
-  //       };
-  //       img.onerror = () => {
-  //         done++;
-  //         res(img);
-  //       }; // пропускаем битые кадры
-  //       img.src = src;
-  //     });
-
-  //   // Загружаем параллельно батчами по 20 чтобы не вешать сеть
-  //   const batch = async (srcs: string[]): Promise<HTMLImageElement[]> => {
-  //     const results: HTMLImageElement[] = [];
-  //     for (let i = 0; i < srcs.length; i += 20) {
-  //       const chunk = srcs.slice(i, i + 20);
-  //       results.push(...(await Promise.all(chunk.map(load))));
-  //     }
-  //     return results;
-  //   };
-
-  //   const [h, t, d] = await Promise.all([
-  //     batch(
-  //       Array.from({ length: HERO_FRAMES }, (_, i) => framePath('hero', i + 1))
-  //     ),
-  //     batch(
-  //       Array.from({ length: TRANSITION_FRAMES }, (_, i) =>
-  //         framePath('transition', i + 1)
-  //       )
-  //     ),
-  //     batch(
-  //       Array.from({ length: DATA_FRAMES }, (_, i) => framePath('data', i + 1))
-  //     ),
-  //   ]);
-
-  //   heroFrames.current = h;
-  //   transFrames.current = t;
-  //   dataFrames.current = d;
-  //   framesReady.current = true;
-  //   setLoaded(true);
-  // }, []);
 
   const snapActive = useRef(false);
 
@@ -237,53 +177,36 @@ export default function LandingPage() {
   }, []);
 
   const updateHint = (t: number) => {
+    // Обновляем шевроны только при скролле в transition section (t > 0)
+    // Иначе они просто имеют CSS анимацию и не меняются каждый фрейм
+    if (t <= 0) {
+      // Hero section — простая CSS анимация, не трогаем
+      return;
+    }
+    
     const el = hintRef.current;
     if (!el) return;
     const rise = t < 0.72 ? t / 0.72 : 1;
     const fly = t > 0.72 ? (t - 0.72) / 0.28 : 0;
 
-    if (t <= 0) {
-      // Idle — на месте
-      chevronRefs.current.forEach((r) => {
-        if (!r) return;
-        r.style.animationDuration = '2s';
-        r.style.transform = 'translateY(0)';
-        r.style.opacity = '1';
-        r.querySelector('polyline')?.setAttribute(
-          'stroke',
-          'rgb(255, 255, 255)'
-        );
-      });
-      const span = el.querySelector('span');
-      if (span) {
-        span.style.letterSpacing = '.44em';
-        span.style.opacity = '1';
-      }
-      el.style.transform = 'translateX(-50%) translateY(0px)';
-      el.style.opacity = '1';
-      el.style.letterSpacing = '.44em';
-      el.style.scale = '1';
-    } else if (t < 0.72) {
+    if (t < 0.72) {
       // Tension — тянется вверх пропорционально прогрессу
       chevronRefs.current.forEach((r, i) => {
         if (!r) return;
-        // Ускоряем анимацию и увеличиваем яркость пропорционально
-        const speed = 1 - rise * 0.6; // от 1s до 0.4s
+        const speed = 1 - rise * 0.6;
         const bright = 0.3 + rise * 0.5;
         r.style.animationDuration = `${speed}s`;
         r.querySelector('polyline')?.setAttribute(
           'stroke',
           `rgba(255,255,255,${bright})`
         );
-        // Смещаем вниз пропорционально индексу — эффект растяжения
-        // Раздвигаем в стороны + вниз — эффект расхождения
-        const side = (i - 1) * rise * 12; // левый летит влево, правый вправо, средний на месте
+        const side = (i - 1) * rise * 12;
         r.style.transform = `translateX(${side}px) translateY(${rise * (i + 1) * 4}px) scaleX(${1 + rise * 0.3})`;
         r.style.opacity = String(0.3 + rise * 0.6);
       });
-      const yUp = rise * 350; // px вверх от низа
-      const sc = 1 + rise * 0.3; // лёгкое растяжение
-      const op = 1 - rise * 0.2; // чуть тускнеет
+      const yUp = rise * 350;
+      const sc = 1 + rise * 0.3;
+      const op = 1 - rise * 0.2;
 
       el.style.transform = `translateX(-50%) translateY(-${yUp}px)`;
       el.style.opacity = String(op);
@@ -398,83 +321,56 @@ export default function LandingPage() {
     ctx.fillRect(0, 0, W, H);
 
     const ph = phase.current,
-      tp = transP.current;
+    tp = transP.current;
 
-    // if (useVisualStore.getState().loadingStage === 'ready') {
-    //   // ── FRAME MODE ──────────────────────────────────────────────────────
-    //   if (ph === 'hero') {
-    //     // Зацикленный hero: инкремент ~25fps
-    //     heroP.current += dt * 0.025;
-    //     const idx = Math.floor(heroP.current % HERO_FRAMES);
-    //     const img = heroFrames.current[idx];
-    //     if (img?.complete) ctx.drawImage(img, 0, 0, W, H);
-    //   } else if (ph === 'transition') {
-    //     // Скраб по scroll position
-    //     const idx = Math.min(
-    //       Math.round(tp * (TRANSITION_FRAMES - 1)),
-    //       TRANSITION_FRAMES - 1
-    //     );
-    //     const img = transFrames.current[idx];
-    //     if (img?.complete) ctx.drawImage(img, 0, 0, W, H);
+    // Кешируем состояние стора один раз за фрейм
+    cachedStoreState.current = useVisualStore.getState();
+    const storeState = cachedStoreState.current;
+    const { videoElements, transitionFrames } = storeState;
+    
+    let videoPlaying = false;
 
-    //     // Ambient particles поверх
-    //     particles(ctx, W, H, 0.25, p);
-    //   } else {
-    //     // Зацикленный data
-    //     dataP.current += dt * 0.025;
-    //     const idx = Math.floor(dataP.current % DATA_FRAMES);
-    //     const img = dataFrames.current[idx];
-    //     if (img?.complete) ctx.drawImage(img, 0, 0, W, H);
-    //   }
-    // } else {
-    //   // ── FALLBACK: canvas заглушка пока кадры грузятся ──────────────────
-    //   if (ph === 'hero' || (ph === 'transition' && tp < 0.5)) {
-    //     chromatic(ctx, W, H, 1, ts);
-    //     particles(ctx, W, H, 1, p);
-    //     horizLine(ctx, W, H, 1, ts);
-    //   } else {
-    //     grid(ctx, W, H, 1, ts);
-    //     chromatic(ctx, W, H, 0.38, ts);
-    //     particles(ctx, W, H, 0.44, p);
-    //     horizLine(ctx, W, H, 1.1, ts);
-    //   }
-    // }
-
-    if (useVisualStore.getState().loadingStage === 'ready') {
-      const { videoElements, transitionFrames } = useVisualStore.getState();
-
+    if (storeState.loadingStage === 'ready') {
       if (ph === 'hero') {
         const vid = videoElements.hero;
-        if (vid && vid.readyState >= 2) ctx.drawImage(vid, 0, 0, W, H);
+        if (vid && vid.readyState >= 2) {
+          ctx.drawImage(vid, 0, 0, W, H);
+          videoPlaying = true;
+        }
       } else if (ph === 'transition') {
         const idx = Math.min(Math.round(tp * (TRANSITION_FRAMES - 1)), TRANSITION_FRAMES - 1);
-        const img = transitionFrames[idx];  // ← из стора, не из локального ref
+        const img = transitionFrames[idx];
         if (img?.complete) ctx.drawImage(img, 0, 0, W, H);
         particles(ctx, W, H, 0.25, p);
       } else {
         const vid = videoElements.data;
-        if (vid && vid.readyState >= 2) ctx.drawImage(vid, 0, 0, W, H);
+        if (vid && vid.readyState >= 2) {
+          ctx.drawImage(vid, 0, 0, W, H);
+          videoPlaying = true;
+        }
       }
     }
 
-    // Горизонтальный градиент сверху/снизу
-    const tg = ctx.createLinearGradient(0, 0, 0, H);
-    tg.addColorStop(0, 'rgba(0,0,10,0.55)');
-    tg.addColorStop(0.12, 'transparent');
-    tg.addColorStop(0.88, 'transparent');
-    tg.addColorStop(1, 'rgba(0,0,10,0.65)');
-    ctx.fillStyle = tg;
-    ctx.fillRect(0, 0, W, H);
-
+    // Градиент фона: только если видео НЕ проигрывается
+    // (иначе лишняя анимация на уже хорошем видео)
+    if (!videoPlaying) {
+      if (!cachedGradient.current) {
+        cachedGradient.current = ctx.createLinearGradient(0, 0, 0, H);
+        cachedGradient.current.addColorStop(0, 'rgba(0,0,10,0.55)');
+        cachedGradient.current.addColorStop(0.12, 'transparent');
+        cachedGradient.current.addColorStop(0.88, 'transparent');
+        cachedGradient.current.addColorStop(1, 'rgba(0,0,10,0.65)');
+      }
+      ctx.fillStyle = cachedGradient.current;
+      ctx.fillRect(0, 0, W, H);
+    }
     requestAnimationFrame(render);
   }, []);
-
   // ── Mount ──────────────────────────────────────────────────────────────────
   useEffect(() => {
     setup();
     applyScroll(window.scrollY);
     requestAnimationFrame(render);
-    initGlobalLoading();
 
     const onScroll = () => {
       // Инерция
@@ -889,7 +785,6 @@ export default function LandingPage() {
             pointerEvents: 'none',
           }}
         >
-          ✦
         </div>
       </div>
     </div>

--- a/web/ui/src/components/auth/auth-button.tsx
+++ b/web/ui/src/components/auth/auth-button.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React from 'react';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AuthButton
+//
+// Единая кнопка для всех форм в auth-зоне. Намеренно не выносится в /ui —
+// её стиль (белый фон, caps, геометрия) специфичен для auth и не должен
+// просачиваться в другие части приложения.
+//
+// Принцип: один компонент — одна ответственность.
+// Кнопка знает только о своём внешнем виде и состоянии загрузки;
+// бизнес-логику (что делать по клику) передаёт потребитель.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Пропсы кнопки авторизации. */
+interface AuthButtonProps {
+  /** Дочерний контент — лейбл кнопки (например, "Initialize", "Sign In"). */
+  children: React.ReactNode;
+
+  /**
+   * Тип HTML-кнопки.
+   * @default "submit"
+   */
+  type?: 'button' | 'submit';
+
+  /**
+   * Когда `true` — кнопка блокируется и показывает анимированный лоадер
+   * вместо текста. Удобно биндить напрямую к стейту `isLoading` формы.
+   */
+  isLoading?: boolean;
+
+  /**
+   * Принудительная блокировка без индикатора загрузки.
+   * Используется, например, для валидации формы до отправки.
+   */
+  disabled?: boolean;
+
+  /** Опциональный обработчик клика. Обычно не нужен при `type="submit"`. */
+  onClick?: () => void;
+}
+
+/**
+ * Кнопка отправки для auth-форм.
+ *
+ * @example
+ * ```tsx
+ * <AuthButton isLoading={isSubmitting}>Initialize</AuthButton>
+ * ```
+ */
+export function AuthButton({
+  children,
+  type = 'submit',
+  isLoading = false,
+  disabled = false,
+  onClick,
+}: AuthButtonProps) {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      // Блокируем кнопку в обоих случаях: явный disabled и состояние загрузки.
+      disabled={disabled || isLoading}
+      className="
+        w-full bg-white text-black
+        font-syne font-black text-[11px] uppercase tracking-[0.3em]
+        py-5 rounded-2xl mt-4
+        hover:bg-zinc-200 active:scale-[0.98]
+        transition-all duration-300
+        disabled:opacity-20 disabled:pointer-events-none
+        shadow-[0_0_20px_rgba(255,255,255,0.1)]
+      "
+    >
+      {/* ── Состояние загрузки: три прыгающих dot'а ── */}
+      {isLoading ? (
+        <span className="flex items-center justify-center gap-2" aria-label="Loading">
+          <span className="w-1 h-1 bg-black rounded-full animate-bounce [animation-delay:-0.3s]" />
+          <span className="w-1 h-1 bg-black rounded-full animate-bounce [animation-delay:-0.15s]" />
+          <span className="w-1 h-1 bg-black rounded-full animate-bounce" />
+        </span>
+      ) : (
+        children
+      )}
+    </button>
+  );
+}

--- a/web/ui/src/components/auth/auth-card.tsx
+++ b/web/ui/src/components/auth/auth-card.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React from 'react';
+import { GlassPane, GlassPaneContent } from '@/components/ui/glass-pane';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AuthCard
+//
+// Стеклянная карточка-контейнер для всех форм в auth-зоне.
+// Инкапсулирует слоистую структуру GlassPane + GlassPaneContent,
+// чтобы потребитель (страница) не знал про детали реализации стекла.
+//
+// Архитектурное решение: вынесен из auth-layout.tsx в отдельный файл,
+// потому что AuthLayout — это про позиционирование и сцену,
+// а AuthCard — про визуальную обёртку контента. Разные ответственности.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Пропсы карточки авторизации. */
+interface AuthCardProps {
+  /** Содержимое карточки — пока что просто форма с инпутами и кнопкой. */
+  children: React.ReactNode;
+}
+
+/**
+ * Стеклянная карточка для auth-форм.
+ * Оборачивает контент в двуслойную структуру: backdrop-blur фон + контентный слой.
+ *
+ * @example
+ * ```tsx
+ * <AuthCard>
+ *   <form>...</form>
+ * </AuthCard>
+ * ```
+ */
+export function AuthCard({ children }: AuthCardProps) {
+  return (
+    // Относительное позиционирование нужно для абсолютно-позиционированного GlassPane внутри.
+    <div className="relative">
+      {/* Ambient glow: размытый белый ореол позади карточки для эффекта свечения. */}
+      <div className="absolute -inset-0.5 bg-white/5 blur-2xl opacity-20 transition duration-1000" />
+
+      {/* ── Слой 1: стеклянный фон (backdrop-blur, box-shadow, хроматические аберрации) ── */}
+      <GlassPane
+        className="inset-0 shadow-2xl"
+        style={{
+          borderRadius: '24px',
+          // Полупрозрачный чёрный фон усиливает читаемость контента на видео-фоне.
+          backgroundColor: 'rgba(0, 0, 0, 0.4)',
+        }}
+      />
+
+      {/* ── Слой 2: контент поверх стекла ── */}
+      <GlassPaneContent className="relative z-10">
+        {children}
+      </GlassPaneContent>
+    </div>
+  );
+}

--- a/web/ui/src/components/auth/auth-layout.tsx
+++ b/web/ui/src/components/auth/auth-layout.tsx
@@ -67,7 +67,21 @@ export function AuthLayout({ children }: { children: React.ReactNode }) {
     const store = useVisualStore.getState();
     store.setScene('auth');
     // Пытаемся запустить видео, если оно уже загружено
-    store.videoElements.data?.play().catch(() => {});
+    if (!store.videoElements.auth) {
+      // Если видео ещё нет в сторе, подписываемся и запускаем по загрузке
+      const unsub = useVisualStore.subscribe(
+        (s) => s.videoElements.auth,
+        (authVideo) => {
+          if (authVideo) {
+            authVideo.play().catch(() => {}); // Не может не удаваться, но на всякий случай ловим
+            unsub(); // отписываемся после первого срабатывания
+          }
+        }
+      );
+
+      return unsub; // отписка при размонтировании
+    }
+    store.videoElements.auth?.play().catch(() => {});
     
     return () => store.setScene('landing');
   }, []);

--- a/web/ui/src/components/auth/index.ts
+++ b/web/ui/src/components/auth/index.ts
@@ -1,0 +1,17 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Barrel Export — Auth Components
+//
+// Единая точка импорта для всех компонентов auth-зоны.
+// Кому нужно, пишут:
+//   import { AuthLayout, AuthCard, AuthButton, FloatingInput } from '@/components/auth';
+// вместо четырёх отдельных импортов.
+//
+// Экспортируем только публичный API зоны.
+// Внутренние хелперы (константы, утилиты) — НЕ экспортируем отсюда.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export { AuthLayout } from './auth-layout';
+export { AuthCard } from './auth-card';
+export { AuthButton } from './auth-button';
+export { FloatingInput } from './floating-input';
+export { DigitBox } from './digit-box';

--- a/web/ui/src/components/layout/background-player.tsx
+++ b/web/ui/src/components/layout/background-player.tsx
@@ -2,15 +2,14 @@
 import { useEffect, useRef } from 'react';
 import { useVisualStore } from '@/store/use-visual-store';
 
-const TRANSITION_FRAMES = 192;
-
 export default function BackgroundPlayer() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const rafRef = useRef<number>();
+  const canvasRef = useRef<HTMLCanvasElement>(null); // Реф для канваса, на котором рисуем видео-фон
+  const rafRef = useRef<number>(); // Реф для ID requestAnimationFrame
 
-  // Все данные из стора через ref — zero re-renders
+  // Все данные из стора через ref => не требуются ререндеры
   const stateRef = useRef(useVisualStore.getState());
 
+  // При монтировании подписываемся на изменения стора и обновляем ref с данными
   useEffect(() => {
     const unsub = useVisualStore.subscribe((s) => {
       stateRef.current = s;
@@ -18,6 +17,7 @@ export default function BackgroundPlayer() {
     return unsub;
   }, []);
 
+  // При монтировании получаем размер канваса и запускаем цикл отрисовки
   useEffect(() => {
     const handleResize = () => {
       const c = canvasRef.current;
@@ -51,29 +51,33 @@ export default function BackgroundPlayer() {
       let source: HTMLImageElement | HTMLVideoElement | null = null;
 
       if (scene === 'auth') {
-        // Auth — всегда data видео
-        const vid = videoElements.data;
+        // Auth — отдельное видео для страниц авторизации
+        const vid = videoElements.auth;
 
         if (vid && vid.readyState >= 2) source = vid;
       } else {
-        // Landing — логика по зонам скролла (идентично page.tsx логике)
+        // Landing — логика по зонам скролла (идентично page.tsx логике): 
+        // первые 15% — hero видео, 15-85% — transition покадрово для скролла, после 85% — data видео
         if (scrollProgress <= 0.15) {
           const vid = videoElements.hero;
           if (vid && vid.readyState >= 2) source = vid;
         } else if (scrollProgress > 0.15 && scrollProgress < 0.85) {
-          // Transition — покадровый скраб
+          // Transition — покадровая анимация, кадр выбирается в зависимости от scrollProgress
           if (transitionFrames.length > 0) {
             const idx = Math.round(scrollProgress * (transitionFrames.length - 1));
             source = transitionFrames[Math.min(idx, transitionFrames.length - 1)];
           }
         } else {
+          // Data — видео для нижней части лендинга
           const vid = videoElements.data;
           if (vid && vid.readyState >= 2) source = vid;
         }
       }
 
       if (source) {
-        // Cover-fit: сохраняем aspect ratio
+        // Если в источнике (видео или картинка) не пусто, рисуем, заполняя весь экран
+        // Для ресайзинга при отрисовке используем формулу масштабирования с сохранением пропорций:
+        // scale = max(W / srcW, H / srcH)
         const srcW = source instanceof HTMLVideoElement ? source.videoWidth : source.naturalWidth;
         const srcH = source instanceof HTMLVideoElement ? source.videoHeight : source.naturalHeight;
         if (srcW > 0 && srcH > 0) {

--- a/web/ui/src/components/layout/client-shell.tsx
+++ b/web/ui/src/components/layout/client-shell.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { useEffect, useRef } from 'react';
-import { useVisualStore } from '@/store/use-visual-store';
+import { useEffect } from 'react';
 import { initGlobalLoading } from '@/lib/visual-orchestrator';
 import BackgroundPlayer from '@/components/layout/background-player';
 

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -33,12 +33,51 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 
   if (!res.ok) {
     const text = await res.text(); // Читаем как текст, чтобы не было SyntaxError
+    console.warn(`[API] ${path} returned ${res.status}:`, text);
     throw new Error(text || `HTTP ${res.status}`);
   }
   const data = await res.json();
 
   return data as T;
 }
+
+// ── Auth API ──────────────────────────────────────────────────────────────────
+
+// ── Media API ────────────────────────────────────────────────────────────────
+
+export interface MediaAsset {
+  section: 'hero' | 'data' | 'auth';
+  url: string;
+  format?: string; // e.g., 'mp4', 'webm'
+  bitrate?: string; // e.g., '720p', '1080p'
+}
+
+export interface MediaConfig {
+  assets: MediaAsset[];
+  timestamp?: number;
+}
+
+export const mediaApi = {
+  /**
+   * Получить конфиг видео-ассетов для всех сцен.
+   * Бэк возвращает массив видеоресурсов с URL'ами.
+   * На фронте это становится источником истины для video paths.
+   * Чтобы менять видео быстро в продакшене — достаточно обновить конфиг на бэке, не трогая фронт.
+   * Пока не реализован соответствующий эндпоинт на бэке — возвращает 401 (вовзрат по умолчанию), MediaManager использует fallback пути.
+   */
+  getMediaConfig: () =>
+    request<MediaConfig>('/api/media/assets'),
+
+  /**
+   * Optional: Получить видео-ассет для конкретной сцены с учетом опций.
+   * Например, можно запрашивать разные видео для разных ролей/стран. 
+   * (пока не нужно, но может пригодиться)
+   */
+  getMediaForScene: (scene: 'hero' | 'data' | 'auth', opts?: { role?: string }) =>
+    request<MediaAsset>(`/api/media/assets/${scene}`, {
+      ...(opts && { body: JSON.stringify(opts) }),
+    }),
+};
 
 // ── Auth API ──────────────────────────────────────────────────────────────────
 

--- a/web/ui/src/lib/media-manager.ts
+++ b/web/ui/src/lib/media-manager.ts
@@ -1,0 +1,112 @@
+/**
+ * MediaManager — управление видео-ассетами для сцен.
+ *
+ * Архитектура:
+ * 1. Кэшируем конфиг видеоресурсов один раз при инициализации (или при смене сцены)
+ * 2. Для каждой сцены ('hero', 'data', 'auth') резолвим URL через конфиг
+ * 3. Поддерживаем динамическую загрузку видео без перезагрузки страницы
+ * 4. Fallback на статические пути, если API недоступен (в данный момент так и есть)
+ *
+ * Использование:
+ *   const mgr = new MediaManager();
+ *   await mgr.init();  // Загружаем конфиг с бэка
+ *   const url = mgr.getVideoUrl('auth');  // Получаем динамический URL
+ */
+
+import { mediaApi, type MediaAsset } from './api';
+
+type Section = 'hero' | 'data' | 'auth';
+
+// Fallback на статические пути, если API недоступен или медленен
+const FALLBACK_VIDEO_PATH = (section: Section, quality: string = '720'): string => {
+  return `/assets/videos/${quality}/${section}_section_animation_${quality}.mp4`;
+};
+
+export class MediaManager {
+  private config: Map<Section, MediaAsset> = new Map();
+  private initialized = false;
+  private initPromise: Promise<void> | null = null;
+
+  /**
+   * Инициализация: fetch конфиг с бэка.
+   * Кэшируется — повторный вызов возвращает сразу.
+   */
+  async init(): Promise<void> {
+    if (this.initialized) return;
+    if (this.initPromise) return this.initPromise;
+
+    this.initPromise = this._initInternal();
+    await this.initPromise;
+  }
+
+  private async _initInternal(): Promise<void> {
+    try {
+      const mediaConfig = await mediaApi.getMediaConfig();
+
+      if (mediaConfig.assets && Array.isArray(mediaConfig.assets)) {
+        mediaConfig.assets.forEach((asset) => {
+          this.config.set(asset.section, asset);
+        });
+      }
+
+      this.initialized = true;
+      console.log('[MediaManager] Loaded config:', Array.from(this.config.entries()));
+    } catch (err) {
+      // 401: Unauthorized — эндпоинт требует аутентификации (или она не настроена)
+      // Это OK для публичного видео-конфига, используем fallback статические пути
+      if (err instanceof Error) {
+        console.warn('[MediaManager] Failed to load media config (using fallback):', err.message);
+      } else {
+        console.warn('[MediaManager] Failed to load media config (using fallback)');
+      }
+      // Fallback: остаемся с пустым конфигом, getVideoUrl вернет fallback
+      this.initialized = true;
+    }
+  }
+
+  /**
+   * Получить URL видео для сцены.
+   * Если конфиг не инициализирован, использует fallback.
+   */
+  getVideoUrl(section: Section, quality: string = '720'): string {
+    const asset = this.config.get(section);
+
+    if (asset && asset.url) {
+      // Если URL относительный (начинается с /) или абсолютный (http/https) — возвращаем как есть
+      // Если это имя файла — предполагаем, что он в /assets/videos/{quality}/
+      if (asset.url.startsWith('/') || asset.url.startsWith('http')) {
+        return asset.url;
+      }
+      // Иначе конструируем полный путь
+      return `/assets/videos/${quality}/${asset.url}`;
+    }
+
+    return FALLBACK_VIDEO_PATH(section, quality);
+  }
+
+  /**
+   * Проверить, инициализирован ли конфиг
+   */
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
+   * Получить полный конфиг (для отладки)
+   */
+  getConfig(): Map<Section, MediaAsset> {
+    return new Map(this.config);
+  }
+
+  /**
+   * Пересоздать конфиг (если нужно обновить видеоресурсы на лету)
+   */
+  async refresh(): Promise<void> {
+    this.initialized = false;
+    this.initPromise = null;
+    await this.init();
+  }
+}
+
+// используется на всех страницах
+export const mediaManager = new MediaManager();

--- a/web/ui/src/lib/visual-orchestrator.ts
+++ b/web/ui/src/lib/visual-orchestrator.ts
@@ -1,25 +1,29 @@
 import { useVisualStore } from '@/store/use-visual-store';
-import { use } from 'react';
+import { mediaManager } from './media-manager';
 
 // ── Конфиг ────────────────────────────────────────────────────────────────────
 const TRANSITION_FRAMES = 192;
 const FRAME_PATH = (n: number) =>
   `/assets/frames/transition/frame_${String(n).padStart(4, '0')}.jpg`;
 
-// Выбираем качество видео по connection (если API доступен)
-function videoPath(section: 'hero' | 'data'): string {
+/**
+ * Выбираем качество видео по connection (если API доступен).
+ * Теперь использует mediaManager для получения URL из динамического конфига.
+ * Fallback на статический путь, если конфиг не загружен.
+ */
+function videoPath(section: 'hero' | 'data' | 'auth'): string {
   const conn = (navigator as any).connection;
   const slow = conn && (conn.saveData || conn.effectiveType === '2g' || conn.effectiveType === '3g');
-  const res = slow ? '720' : '720'; // На самом деле на 4к просто все лагает дико так что пока что 720
-  return `/assets/videos/${res}/${section}_section_animation_${res}.mp4`;
+  const quality = slow ? '720' : '720'; // На самом деле на 4к просто все лагает дико так что пока что 720
+
+  // Получаем URL через mediaManager (будет использован конфиг с бэка, если доступен)
+  return mediaManager.getVideoUrl(section, quality);
 }
 
-// Создаем кэш вне функции, чтобы он никогда не пересоздавался
-const videoCache: Record<string, HTMLVideoElement> = {};
 // ── loadVideo ─────────────────────────────────────────────────────────────────
 // Грузим видео и трекаем прогресс через buffered API
 function loadVideo(
-  section: 'hero' | 'data',
+  section: 'hero' | 'data' | 'auth',
   onProgress: (pct: number) => void
 ): Promise<HTMLVideoElement> {
   return new Promise((resolve, reject) => {
@@ -92,12 +96,21 @@ function loadTransitionFrames(
 export async function initGlobalLoading() {
   const store = useVisualStore.getState();
 
+  // ── Инициализируем MediaManager (загружаем конфиг с бэка для видеоресурсов) ──
+  // Это будет выполняться параллельно с загрузкой видео
+  // Если бэк недоступен, mediaManager будет использовать fallback пути
+  const mediaInitPromise = mediaManager.init().catch((err) => {
+    console.warn('[initGlobalLoading] MediaManager init failed, using fallbacks:', err);
+  });
+
   // Кеш-проверка: если всё уже загружено — ничего не делаем
   if (
     store.videoElements.hero &&
     store.videoElements.data &&
     store.transitionFrames.length > 0
   ) {
+    // Даже если кэш полон, ждём инициализации MediaManager
+    await mediaInitPromise;
     store.setLoadingStage('ready');
     store.setLoadProgress(100);
     return;
@@ -105,11 +118,11 @@ export async function initGlobalLoading() {
 
   // Веса для суммарного прогресса: hero 25% + transition 55% + data 20%
   // Потом подкрутим под реальные размеры файлов
-  const W = { hero: 0.25, transition: 0.55, data: 0.20 };
-  let heroP = 0, transP = 0, dataP = 0;
+  const W = { hero: 0.25, transition: 0.55, data: 0.10, auth: 0.10 };
+  let heroP = 0, transP = 0, dataP = 0, authP = 0;
 
   const pushProgress = () => {
-    const total = heroP * W.hero + transP * W.transition + dataP * W.data;
+    const total = heroP * W.hero + transP * W.transition + dataP * W.data + authP * W.auth;
     store.setLoadProgress(Math.round(total * 100));
   };
 
@@ -117,11 +130,6 @@ export async function initGlobalLoading() {
   store.setLoadingStage('hero');
   let heroVideo = store.videoElements.hero;
 
-  // Если hero уже кешировано — пропускаем
-  // Браузер (низший уровень) — качает байты видео и постоянно дергает событие onprogress.
-  // loadVideo (средний уровень) — ловит эти байты, пересчитывает их в проценты и вызывает ту функцию, которую в него передали под именем onProgress.
-  // Стрелочная функция (p) => { ... } (...) принимает процент p и тут же пинает pushProgress().
-  // pushProgress() (высший уровень) — собирает данные от всех видео сразу, суммирует их и говорит Zustand-стору обновить прогресс бар.
   if (!store.videoElements.hero) {
     heroVideo = await loadVideo('hero', (p) => {
       heroP = p;
@@ -158,11 +166,33 @@ export async function initGlobalLoading() {
   dataP = 1;
   pushProgress();
 
+  store.setLoadingStage('auth');
+  let authVideo = store.videoElements.auth;
+
+  if (!store.videoElements.auth) {
+    authVideo = await loadVideo('auth', (p) => {
+      authP = p;
+      pushProgress();
+    });
+    store.setVideoElement('auth', authVideo);
+  }
+  authP = 1;
+  pushProgress();
+
+  // ── Ждём инициализации MediaManager ───────────────────────────────────────
+  // Это гарантирует, что конфиг видеоресурсов загружен перед попаданием на auth
+  await mediaInitPromise;
+
   // ── Готово ────────────────────────────────────────────────────────────────
   store.setLoadingStage('ready');
   store.setLoadProgress(100);
 
+  // TODO: Разобраться с автоплеем, сейчас он работает но возможно запускает оба видео одновременно
   if (heroVideo) {
     heroVideo.play().catch(() => {});
+  }
+
+  if (authVideo) {
+    authVideo.play().catch(() => {});
   }
 }

--- a/web/ui/src/store/use-visual-store.ts
+++ b/web/ui/src/store/use-visual-store.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 
 type Scene = 'landing' | 'auth';
-type LoadingStage = 'hero' | 'transition' | 'data' | 'ready';
+type LoadingStage = 'hero' | 'transition' | 'data' | 'ready' | 'auth';
 
 interface VisualState {
   scene: Scene;
@@ -19,6 +19,7 @@ interface VisualState {
   videoElements: {
     hero: HTMLVideoElement | null;
     data: HTMLVideoElement | null;
+    auth: HTMLVideoElement | null;
   };
 
   // Методы
@@ -27,7 +28,7 @@ interface VisualState {
   setLoadProgress: (progress: number) => void;
   setScrollProgress: (progress: number) => void;
   setTransitionFrames: (frames: HTMLImageElement[]) => void;
-  setVideoElement: (section: 'hero' | 'data', el: HTMLVideoElement) => void;
+  setVideoElement: (section: 'hero' | 'data' | 'auth', el: HTMLVideoElement) => void;
 }
 
 export const useVisualStore = create<VisualState>() (
@@ -37,7 +38,7 @@ export const useVisualStore = create<VisualState>() (
     loadProgress: 0,
     scrollProgress: 0,
     transitionFrames: [],
-    videoElements: { hero: null, data: null },
+    videoElements: { hero: null, data: null, auth: null },
     sessionId: typeof window !== 'undefined' ? localStorage.getItem('h_session') : null,
     setSessionId: (id) => {
       if (id) localStorage.setItem('h_session', id);


### PR DESCRIPTION
## Summary
Linked Issue: #68

Implement API-driven scene-based media loading and integrate it with the visual orchestrator and auth pages.

Technical summary:
- Add `MediaManager` singleton to fetch and resolve media asset URLs from `GET /api/media/assets` with fallbacks.
- Add `mediaApi.getMediaConfig()` to `lib/api.ts` and consume it from the media manager.
- Integrate media manager into `initGlobalLoading()` so hero/data/auth media are loaded and cached in the visual store.
- Extend `use-visual-store` and orchestrator to include `auth` video element and transition frames.
- Introduce `AuthCard` / `AuthButton` components and barrel export `@/components/auth` to standardize auth UI; update login/register pages to use them.
- Add documentation `docs/AUTH_MEDIA_INTEGRATION.md` and `docs/SCENE_BASED_VIDEO_ARCHITECTURE.md`.

## Type of Change
- [x] FEAT: New functionality
- [ ] FIX: Bug fix
- [x] REFACTOR: Code change
- [ ] PERF: Performance improvement
- [ ] BUILD: Changes affecting build system or dependencies

## Verification Results
### Automated Tests
- Unit Tests: NA
- Integration Tests: NA
- Coverage Change: NA

### Manual Verification
- Ran local type/error scan on changed frontend files (no import/module errors).
- Verified `login` and `register` pages import from `@/components/auth` barrel and use `AuthButton`.
- Verified `mediaManager` present and `visual-orchestrator` calls `mediaManager.init()` path in code.
- Manual smoke: auth flow still triggers `handleLogin` via form submit and `AuthButton` is used as `type="submit"`.

## Compliance Checklist
- [x] Commits follow Conventional Commits specification.
- [x] No sensitive data included.
- [x] Linear history maintained.

Closes #68 