### PR TITLE
feat(auth): polish, comment otp box and floating input primitives

### DIFF
--- a/web/ui/src/components/auth/digit-box.tsx
+++ b/web/ui/src/components/auth/digit-box.tsx
@@ -3,27 +3,77 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 
-export const DigitBox = ({ value, index, isTyping }: { value: string, index: number, isTyping: boolean }) => {
+// ─────────────────────────────────────────────────────────────────────────────
+// DigitBox
+//
+// Одна ячейка OTP-кода. При получении значения воспроизводит анимацию:
+//   1. "Домино-прыжок" - ячейка подпрыгивает со смещением по времени (delay = index * 100ms)
+//   2. Перебор случайных цифр - имитация "слот-машины" перед остановкой на нужной цифре
+//
+// Используется в массиве: цифры кода рендерятся через .map() с передачей index,
+// что создаёт каскадный эффект при вводе.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Пропсы одной ячейки OTP. */
+interface DigitBoxProps {
+  /** Итоговое значение цифры (строка "0"-"9" или пустая строка если цифра ещё не введена). */
+  value: string;
+
+  /**
+   * Порядковый индекс ячейки в ряду (0-based).
+   * Используется для расчёта задержки анимации - каждая следующая
+   * ячейка прыгает и крутится чуть дольше, создавая эффект домино.
+   */
+  index: number;
+
+  /**
+   * Флаг активной анимации. Когда `true` - запускает перебор цифр и прыжок.
+   * Контролируется родителем: `true` в момент ввода, `false` в состоянии покоя.
+   */
+  isTyping: boolean;
+}
+
+/**
+ * Анимированная ячейка одной цифры OTP-кода.
+ *
+ * @example
+ * ```tsx
+ * {otpDigits.map((digit, i) => (
+ *   <DigitBox key={i} value={digit} index={i} isTyping={isAnimating} />
+ * ))}
+ * ```
+ */
+export function DigitBox({ value, index, isTyping }: DigitBoxProps) {
+  // Отображаемое значение может отличаться от `value` во время анимации перебора.
   const [displayValue, setDisplayValue] = useState('0');
 
   useEffect(() => {
-    // Если включен режим анимации (typing), запускаем перебор цифр
+    // Анимация запускается только если: режим typing активен И значение уже есть.
     if (isTyping && value !== '') {
       let iterations = 0;
-      // Асинхронность: каждая следующая ячейка крутится чуть дольше
-      const maxIterations = 6 + index * 3; 
-      
+
+      // Каждая следующая ячейка крутится на 3 итерации дольше предыдущей —
+      // визуальный эффект "нарастающего" домино.
+      const maxIterations = 6 + index * 3;
+
       const interval = setInterval(() => {
+        // Показываем случайную цифру каждые 70ms — имитация слот-машины.
         setDisplayValue(Math.floor(Math.random() * 10).toString());
         iterations++;
-        
+
         if (iterations >= maxIterations) {
+          // Остановка: фиксируем итоговое значение.
           setDisplayValue(value);
           clearInterval(interval);
         }
       }, 70);
+
+      // Cleanup: если компонент размонтируется до окончания анимации -
+      // clearInterval предотвращает утечку памяти и setState на мёртвый компонент.
       return () => clearInterval(interval);
     } else {
+      // Без анимации: просто отображаем значение напрямую.
+      // Пустая строка → отображаем пусто (не "0"), чтобы незаполненные ячейки выглядели пусто.
       setDisplayValue(value || '');
     }
   }, [value, isTyping, index]);
@@ -31,17 +81,30 @@ export const DigitBox = ({ value, index, isTyping }: { value: string, index: num
   return (
     <motion.div
       initial={{ y: 0 }}
-      animate={isTyping ? { 
-        y: [0, -12, 0], // Эффект прыжка домино
-        transition: { delay: index * 0.1, duration: 0.4, ease: "easeOut" } 
-      } : {}}
-      className={`w-12 h-16 flex items-center justify-center rounded-xl border font-geist-mono text-2xl
-        ${value 
-          ? 'bg-white/10 border-white/30 text-white text-glow shadow-[0_0_15px_rgba(255,255,255,0.1)]' 
-          : 'bg-white/2 border-white/10 text-white/50'
-        } transition-all duration-300`}
+      animate={
+        isTyping
+          ? {
+              // Эффект прыжка: ячейка подпрыгивает на 12px и возвращается.
+              // `delay: index * 0.1` - каскад: каждая следующая прыгает позже.
+              y: [0, -12, 0],
+              transition: { delay: index * 0.1, duration: 0.4, ease: 'easeOut' },
+            }
+          : {}
+      }
+      className={`
+        w-12 h-16 flex items-center justify-center
+        rounded-xl border font-geist-mono text-2xl
+        transition-all duration-300
+        ${
+          value
+            ? // Заполненная ячейка: яркая, с лёгким свечением.
+              'bg-white/10 border-white/30 text-white text-glow shadow-[0_0_15px_rgba(255,255,255,0.1)]'
+            : // Пустая ячейка: приглушённая, почти невидимая.
+              'bg-white/2 border-white/10 text-white/50'
+        }
+      `}
     >
       {displayValue}
     </motion.div>
   );
-};
+}

--- a/web/ui/src/components/auth/floating-input.tsx
+++ b/web/ui/src/components/auth/floating-input.tsx
@@ -1,91 +1,189 @@
+'use client';
+
 import { motion, AnimatePresence } from 'framer-motion';
 import { useState } from 'react';
 
-const INPUT_CLASS = `w-full rounded-2xl px-5 py-4
-  text-white text-[17px] outline-none transition-all
+// ─────────────────────────────────────────────────────────────────────────────
+// FloatingInput
+//
+// Инпут с анимированной плавающей меткой (floating label pattern).
+// При фокусе или непустом значении метка "улетает" вверх и уменьшается,
+// освобождая место для вводимого текста.
+//
+// Дополнительно:
+//   - Placeholder появляется только при фокусе + пустом значении (через AnimatePresence)
+//   - Декоративная градиентная линия снизу при фокусе
+//   - Хроматические аберрации на стекле (через INPUT_CLASS/backdrop-filter)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Базовые CSS-классы для `<input>`.
+ * Вынесены в константу для читаемости и переиспользования в будущем.
+ *
+ * Главные моменты:
+ * - `placeholder-transparent`: скрываем нативный placeholder - он управляется вручную через AnimatePresence.
+ * - `peer`: позволяет стилизовать соседние элементы через Tailwind `peer-*` (не используется здесь, но задел на будущее).
+ * - `backdrop-blur-3xl backdrop-saturate-[180%]`: имитация матового стекла, согласованная с GlassPane.
+ */
+const INPUT_CLASS = `
+  w-full rounded-2xl px-5 py-4
+  text-white text-[17px] outline-none
   font-mono tracking-wider placeholder-transparent
   bg-black/80 border border-white/10
   backdrop-blur-3xl backdrop-saturate-[180%]
   shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]
-  focus:border-white/25 focus:bg-black/100 peer`;
+  focus:border-white/25 focus:bg-black/100
+  transition-all peer
+`;
 
-export function FloatingInput({ 
-    label, 
-    value, 
-    onChange, 
-    type = "text", 
-    placeholder,
-    autoComplete 
-  }: { 
-    label: string; 
-    value: string; 
-    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-    type?: string;
-    placeholder?: string;
-    autoComplete?: string;
-  }) {
-    const [isFocused, setIsFocused] = useState(false);
-    // Определяем, должна ли метка "улететь" наверх
-    const isFloating = isFocused || value.length > 0;
-  
-    return (
-      <div className="relative group w-full">
-        {/* Метка-заголовок */}
-        <motion.label
-          initial={false}
-          animate={{
-            // Базовое состояние: -50% (центрирование по вертикали) (считается от начального top-1/2)
-            // top-1/2 = 50% от высоты контейнера, минус 50% от своей высоты = идеально центрировано
-            // Активное состояние: улетает вверх на расстояние трех себя
-            y: isFloating ? "-250%" : "-50%",
-            x: isFloating ? "-10px" : "0%",
-            scale: isFloating ? 0.85 : 1,
-            opacity: isFloating ? 1 : 0.85,
-            color: isFloating ? "rgba(255, 255, 255, 0.4)" : "rgba(255, 255, 255, 0.3)",
-          }}
-          transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
-          className="absolute top-1/2 left-5 pointer-events-none 
-                     font-mono text-sm uppercase tracking-widest text-white 
-                     origin-left z-10"
+/** Пропсы компонента FloatingInput. */
+interface FloatingInputProps {
+  /** Текст метки — отображается как floating label. */
+  label: string;
+
+  /** Текущее значение инпута (controlled component). */
+  value: string;
+
+  /** Обработчик изменения значения. */
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+
+  /**
+   * HTML-тип инпута.
+   * @default "text"
+   */
+  type?: string;
+
+  /**
+   * Подсказка, которая показывается внутри поля только при фокусе и пустом значении.
+   * В отличие от нативного `placeholder`, анимируется через AnimatePresence.
+   */
+  placeholder?: string;
+
+  /**
+   * Атрибут `autocomplete` для браузерного автозаполнения.
+   * Рекомендуется передавать явно: `"email"`, `"current-password"`, `"new-password"` и т.д.
+   */
+  autoComplete?: string;
+}
+
+/**
+ * Инпут с анимированной плавающей меткой для auth-форм.
+ *
+ * @example
+ * ```tsx
+ * <FloatingInput
+ *   label="Email"
+ *   value={email}
+ *   onChange={e => setEmail(e.target.value)}
+ *   placeholder="user@example.com"
+ *   autoComplete="email"
+ * />
+ * ```
+ */
+export function FloatingInput({
+  label,
+  value,
+  onChange,
+  type = 'text',
+  placeholder,
+  autoComplete,
+}: FloatingInputProps) {
+  // Локальный стейт фокуса нужен только для управления анимациями.
+  // Сам инпут - controlled через пропсы value/onChange.
+  const [isFocused, setIsFocused] = useState(false);
+
+  /**
+   * Метка "улетает" вверх если:
+   * - Поле в фокусе (пользователь набирает текст), ИЛИ
+   * - Поле уже содержит значение (чтобы метка не перекрывала введённый текст).
+   */
+  const isFloating = isFocused || value.length > 0;
+
+  return (
+    // `group` позволяет в будущем стилизовать дочерние элементы через `group-hover`.
+    <div className="relative group w-full">
+
+      {/* ── Floating Label ──
+          Анимируется через Framer Motion animate-объект.
+          `initial={false}` отключает вступительную анимацию при первом рендере -
+          метка сразу рендерится в правильном состоянии. */}
+      <motion.label
+        initial={false}
+        animate={{
+          // Центрирование: top-1/2 в CSS + translateY(-50%) = вертикальный центр.
+          // В активном состоянии метка поднимается на 250% вверх от своей высоты.
+          y: isFloating ? '-250%' : '-50%',
+          // Лёгкий сдвиг влево при floating для оптической выравненности.
+          x: isFloating ? '-10px' : '0%',
+          scale: isFloating ? 0.85 : 1,
+          opacity: isFloating ? 1 : 0.85,
+          color: isFloating
+            ? 'rgba(255, 255, 255, 0.4)'
+            : 'rgba(255, 255, 255, 0.3)',
+        }}
+        transition={{
+          duration: 0.5,
+          // Custom cubic-bezier: плавный выход с "пружинным" эффектом.
+          ease: [0.16, 1, 0.3, 1],
+        }}
+        className="
+          absolute top-1/2 left-5
+          pointer-events-none
+          font-mono text-sm uppercase tracking-widest text-white
+          origin-left z-10
+        "
+      >
+        {label}
+      </motion.label>
+
+      {/* ── Кастомный Placeholder ──
+          Показывается только при фокусе и пустом значении.
+          AnimatePresence управляет появлением/исчезновением через opacity. */}
+      <AnimatePresence>
+        {isFocused && !value && (
+          <motion.span
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            className="
+              absolute left-5 top-1/2 -translate-y-1/2
+              pointer-events-none
+              font-mono text-[15px] text-zinc-600
+              z-10
+            "
           >
-          {label}
-        </motion.label>
-        
-        {/* Плейсхолдер (появляется только при фокусе и пустом значении) */}
-        <AnimatePresence>
-          {isFocused && !value && (
-            <motion.span
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.3 }}
-              className="absolute left-5 top-1/2 -translate-y-1/2 pointer-events-none font-mono text-[15px] text-zinc-600 z-10"
-            >
-              {placeholder}
-            </motion.span>
-          )}
-        </AnimatePresence>
-  
-        {/* Инпут */}
-        <input
-          type={type}
-          value={value}
-          onChange={onChange}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          autoComplete={autoComplete}
-          placeholder=""
-          // Плейсхолдер показываем только при фокусе
-          className={`${INPUT_CLASS}`}
-        />
-  
-        {/* Декоративная линия фокуса */}
-        <motion.div 
-          className="absolute bottom-0 left-0 right-0 h-[1px] bg-gradient-to-r from-transparent via-white/20 to-transparent"
-          initial={{ scaleX: 0, opacity: 0 }}
-          animate={{ scaleX: isFocused ? 1 : 0, opacity: isFocused ? 1 : 0 }}
-          transition={{ duration: 0.6 }}
-        />
-      </div>
-    );
-  }
+            {placeholder}
+          </motion.span>
+        )}
+      </AnimatePresence>
+
+      {/* ── Input ──
+          `placeholder=""` - пустой нативный placeholder, т.к. мы управляем им вручную выше.
+          onFocus/onBlur обновляют только локальный isFocused, не трогая внешний стейт. */}
+      <input
+        type={type}
+        value={value}
+        onChange={onChange}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        autoComplete={autoComplete}
+        placeholder=""
+        className={INPUT_CLASS}
+      />
+
+      {/* ── Декоративная линия фокуса ──
+          Градиент от прозрачного к белому и обратно - подчёркивает активное поле
+          без агрессивного outline. scaleX: 0=>1 анимирует "раскрытие" линии. */}
+      <motion.div
+        className="absolute bottom-0 left-0 right-0 h-[1px] bg-gradient-to-r from-transparent via-white/20 to-transparent"
+        initial={{ scaleX: 0, opacity: 0 }}
+        animate={{
+          scaleX: isFocused ? 1 : 0,
+          opacity: isFocused ? 1 : 0,
+        }}
+        transition={{ duration: 0.6 }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Linked Issue: #68

Refine the shared auth input primitives so login and registration screens use the same OTP and floating-label behavior. This improves consistency across auth pages and keeps the component API reusable for future auth flows.

## Type of Change
- [x] FEAT: New functionality
- [ ] FIX: Bug fix
- [x] REFACTOR: Code change
- [ ] PERF: Performance improvement
- [ ] BUILD: Changes affecting build system or dependencies

## Verification Results
### Automated Tests
- Unit Tests: NA
- Integration Tests: NA
- Coverage Change: NA

### Manual Verification
Reviewed `DigitBox` and `FloatingInput` for shared auth usage and consistent controlled-input behavior.

## Compliance Checklist
- [x] Commits follow Conventional Commits specification.
- [x] Documentation updated.
- [x] No sensitive data included.
- [x] Linear history maintained.

Closes #68