### PR TITLE
fix(collector): persist presence activity updates

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -27,7 +27,8 @@ type XrayClient interface {
 // PresenceStore — минимальный контракт кэша online/offline статусов.
 // Коллектор пишет в этот кэш после каждой попытки опроса Xray.
 type PresenceStore interface {
-	Set(email string, online bool)
+	SetStats(email string, uplink, downlink int64)
+	IsOnline(email string) bool
 }
 
 type Collector struct {
@@ -88,15 +89,15 @@ func (c *Collector) tick(ctx context.Context) {
 
 		stats, err := c.xray.GetUserStats(ctx, user.Email)
 		if err != nil {
-			if c.presence != nil {
-				c.presence.Set(user.Email, false)
-			}
-			// Ошибка одного пользователя не останавливает остальных.
+			// Ошибка при получении stats — нет информации об активности
+			// Оставляем lastActivity как была, IsOnline проверит timeout
 			slog.Error("collector: failed to fetch stats from Xray API", "email", user.Email, "error", err)
 			continue
 		}
+
+		// Обновляем статистику и автоматически меняем online/offline на основе прироста трафика
 		if c.presence != nil {
-			c.presence.Set(user.Email, true)
+			c.presence.SetStats(user.Email, stats.Uplink, stats.Downlink)
 		}
 
 		// Лимит: Downlink + Uplink

--- a/internal/collector/presence.go
+++ b/internal/collector/presence.go
@@ -1,24 +1,69 @@
 package collector
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
+
+type userPresence struct {
+	lastActivity time.Time
+	totalUplink  int64
+	totalDownlink int64
+}
 
 type PresenceCache struct {
-	mu    sync.RWMutex
-	state map[string]bool
+	mu       sync.RWMutex
+	state    map[string]userPresence
+	timeout  time.Duration // порог неактивности для offline
 }
 
 func NewPresenceCache() *PresenceCache {
-	return &PresenceCache{state: make(map[string]bool)}
+	return &PresenceCache{
+		state:   make(map[string]userPresence),
+		timeout: 10 * time.Second, // если 10 секунд нет трафика — считаем offline
+	}
 }
 
-func (p *PresenceCache) Set(email string, online bool) {
+// SetStats обновляет статистику и время последней активности.
+// Если трафик изменился (новые данные больше предыдущих) — обновляем lastActivity.
+// Если трафик не изменился — lastActivity остается как была.
+func (p *PresenceCache) SetStats(email string, uplink, downlink int64) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.state[email] = online
+
+	prev, exists := p.state[email]
+	now := time.Now()
+
+	// Проверяем, был ли прирост трафика
+	hasNewTraffic := uplink > prev.totalUplink || downlink > prev.totalDownlink
+
+	// Обновляем время активности только если есть новый трафик
+	lastActivity := prev.lastActivity
+	if hasNewTraffic || !exists {
+		lastActivity = now
+	}
+
+	p.state[email] = userPresence{
+		lastActivity:  lastActivity,
+		totalUplink:   uplink,
+		totalDownlink: downlink,
+	}
 }
 
 func (p *PresenceCache) IsOnline(email string) bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return p.state[email]
+
+	presence, exists := p.state[email]
+	if !exists {
+		return false
+	}
+
+	// Если активность была недавно — онлайн
+	if time.Since(presence.lastActivity) < p.timeout {
+		return true
+	}
+
+	// Если давно неактивен — офлайн
+	return false
 }


### PR DESCRIPTION
## Summary

Fix collector presence cache: ensure presence cache updates last-activity only when new traffic arrives and rely on timestamp-based online/offline checks. Keeps collector behaviour stable and avoids false-online statuses.

## Type of Change
- [ ] FEAT: New functionality
- [x] FIX: Bug fix
- [ ] REFACTOR: Code change
- [ ] PERF: Performance improvement
- [ ] BUILD: Changes affecting build system or dependencies

## Verification Results
### Automated Tests
- Unit Tests: NA
- Integration Tests: NA
- Coverage Change: NA

### Manual Verification
- Run collector with a test store/xray client and assert presence.IsOnline toggles to true only after traffic increase.
- Observe saved history entries in DB and pipeline submissions on limit exceed.

## Compliance Checklist
- [x] Commits follow Conventional Commits specification.
- [x] Documentation updated.
- [x] No sensitive data included.
- [x] Linear history maintained.