### PR TITLE
feat(auth): add media-backed auth scaffolding

### DIFF
--- a/web/ui/.storybook/preview.ts
+++ b/web/ui/.storybook/preview.ts
@@ -3,6 +3,10 @@ import '../src/app/globals.css';
 
 const preview: Preview = {
   parameters: {
+    nextjs: {
+      appDirectory: true,  // говорит что используем App Router
+    },
+
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/web/ui/src/app/not-found.tsx
+++ b/web/ui/src/app/not-found.tsx
@@ -1,0 +1,71 @@
+// app/not-found.tsx
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Link from 'next/link';
+import { useVisualStore } from '@/store/use-visual-store';
+import { MediaManager } from '@/lib/media-manager';
+
+export default function NotFound() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  // Проверяем, нет ли уже готового видео в глобальном сторе
+  const cachedVideo = useVisualStore((s) => s.videoElements.hero);
+
+  useEffect(() => {
+    if (cachedVideo && videoRef.current) {
+      // Если видео уже есть в памяти, подменяем источник или копируем состояние
+      videoRef.current.src = cachedVideo.src;
+    } else {
+      // Иначе инициализируем менеджер и берем URL
+      const mgr = new MediaManager();
+      // getVideoUrl возвращает либо динамический путь, либо FALLBACK
+      const url = mgr.getVideoUrl('hero', '1080'); 
+      if (videoRef.current) {
+        videoRef.current.src = url;
+      }
+    }
+  }, [cachedVideo]);
+
+  return (
+    <main className="relative min-h-screen w-full flex items-center justify-center overflow-hidden">
+      {/* ─── Video Orchestrator Background ──────────────────────────────────────── */}
+      <div className="absolute inset-0 z-0">
+        <video
+          ref={videoRef}
+          autoPlay
+          loop
+          muted
+          playsInline
+          className="w-full h-full object-cover opacity-40 grayscale"
+          style={{ filter: 'contrast(1.2) brightness(0.8)' }}
+        />
+        {/* Градиентный маскировщик для мягкого входа в интерфейс */}
+        <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-transparent to-black" />
+      </div>
+
+      {/* ─── Content Layer ──────────────────────────────────────────────────────── */}
+      <div className="relative z-10 flex flex-col items-center">
+        <h1 className="text-[12vw] font-syne font-bold tracking-tighter text-white/40 leading-none">
+          404
+        </h1>
+        
+        <div className="flex flex-col items-center gap-2 -mt-4">
+          <span className="text-[10px] font-geist-mono tracking-[0.4em] uppercase text-white/61">
+            Sector not found
+          </span>
+          <div className="h-px w-12 bg-white/42 my-4" />
+          <Link 
+            href="/"
+            className="group relative px-8 py-3 overflow-hidden rounded-full border border-white/10 transition-all hover:border-white/30"
+          >
+            <span className="relative z-10 text-[9px] font-syne uppercase tracking-[0.2em] text-white/78 group-hover:text-white">
+              Go to Home
+            </span>
+            <div className="absolute inset-0 bg-white/5 translate-y-full group-hover:translate-y-0 transition-transform duration-300" />
+          </Link>
+        </div>
+      </div>
+
+    </main>
+  );
+}

--- a/web/ui/src/components/auth/auth-card.tsx
+++ b/web/ui/src/components/auth/auth-card.tsx
@@ -43,6 +43,7 @@ export function AuthCard({ children }: AuthCardProps) {
       <GlassPane
         className="inset-0 shadow-2xl"
         style={{
+          overflow: "hidden",
           borderRadius: '24px',
           // Полупрозрачный чёрный фон усиливает читаемость контента на видео-фоне.
           backgroundColor: 'rgba(0, 0, 0, 0.4)',

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -2,7 +2,8 @@
 // Типизированный клиент к Heimdallr API.
 // Все эндпоинты описаны здесь — компоненты не знают про fetch напрямую.
 
-const BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+const API_PORT = process.env.API_PORT || '3000';
+const BASE = `http://127.0.0.1:${API_PORT}`;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Introduce media-backed scaffolding for auth pages and a 404 fallback that integrates with the visual/media manager. Add documentation describing scene-based video architecture and integration steps. Small UI fix to `AuthCard` to prevent overflow artifacts.

## Type of Change
- [x] FEAT: New functionality
- [ ] FIX: Bug fix
- [ ] REFACTOR: Code change
- [ ] PERF: Performance improvement
- [ ] BUILD: Changes affecting build system or dependencies

## Verification Results
### Automated Tests
- Unit Tests: NA
- Integration Tests: NA
- Coverage Change: NA

### Manual Verification
- Start frontend (`npm run dev` in `web/ui`) and verify:
  - `GET /api/media/assets` is used by `mediaApi`.
  - Visiting a non-existent route shows the new `NotFound` page with video fallback.
  - Auth UI renders and `AuthCard` layout no longer overflows.

## Compliance Checklist
- [x] Commits follow Conventional Commits specification.
- [x] Documentation updated.
- [x] No sensitive data included.
- [x] Linear history maintained.