### PR TITLE
fix(collector): serve cached presence stats and recover missing users

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -34,6 +34,8 @@ type HistoryProvider interface {
 	GetHistory(ctx context.Context, email string, limit int) ([]models.UserHistory, error)
 }
 
+
+
 // OTPStore — всё что серверу нужно от БД для работы с OTP.
 type OTPStore interface {
 	SaveOTP(ctx context.Context, otp *models.OTPCode) error
@@ -79,11 +81,15 @@ type XrayUserManager interface {
 	RemoveUser(ctx context.Context, inboundTag, email string) error
 }
 
-// PresenceProvider — read-only доступ к online/offline кэшу.
-// API использует этот интерфейс для обогащения списка пользователей.
+// PresenceProvider — интерфейс для server.go.
+// GetAllStats добавлен вместо GetTotalStats: фронт получает данные
+// по каждому юзеру и агрегирует сам если нужно.
 type PresenceProvider interface {
 	IsOnline(email string) bool
+	// GetAllStats возвращает срез со статистикой каждого пользователя из кэша.
+	GetAllStats() []models.UserStats
 }
+
 
 // --- Структура сервера ---
 type Server struct {
@@ -678,12 +684,7 @@ func (s *Server) parseJWT(tokenStr string) (*jwtClaims, error) {
 
 // GET /api/stats — статистика в текущий момент
 func (s *Server) handleStats(c echo.Context) error {
-	stats, err := s.statsProvider.GetUserStats(c.Request().Context(), s.adminEmail)
-	if err != nil {
-		slog.Error("api: failed to get stats", "error", err, "remote_ip", c.RealIP())
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
-	}
-	return c.JSON(http.StatusOK, stats)
+	return c.JSON(http.StatusOK, s.presence.GetAllStats())
 }
 
 // GET /api/history?limit=100 — история из БД

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -22,6 +22,7 @@ type CollectorStore interface {
 // он может быть недоступен пока Store работает нормально.
 type XrayClient interface {
 	GetUserStats(ctx context.Context, email string) (models.UserStats, error)
+	AddUser(ctx context.Context, user models.User) error
 }
 
 // PresenceStore — минимальный контракт кэша online/offline статусов.
@@ -92,6 +93,10 @@ func (c *Collector) tick(ctx context.Context) {
 			// Ошибка при получении stats — нет информации об активности
 			// Оставляем lastActivity как была, IsOnline проверит timeout
 			slog.Error("collector: failed to fetch stats from Xray API", "email", user.Email, "error", err)
+			err := c.xray.AddUser(ctx, user) // Пытаемся добавить пользователя в Xray, если его там нет
+			if err != nil {
+				slog.Error("collector: failed to add user to Xray", "email", user.Email, "error", err)
+			}
 			continue
 		}
 

--- a/internal/collector/presence.go
+++ b/internal/collector/presence.go
@@ -3,6 +3,8 @@ package collector
 import (
 	"sync"
 	"time"
+
+	"github.com/ZeroD1vision/heimdallr-proxy/internal/models"
 )
 
 type userPresence struct {
@@ -11,11 +13,15 @@ type userPresence struct {
 	totalDownlink int64
 }
 
+// PresenceCache — in-memory кэш онлайн-статусов и трафика.
+// Коллектор пишет сюда на каждом тике через SetStats.
+// API читает отсюда — без обращений к Xray напрямую.
 type PresenceCache struct {
 	mu       sync.RWMutex
 	state    map[string]userPresence
 	timeout  time.Duration // порог неактивности для offline
 }
+
 
 func NewPresenceCache() *PresenceCache {
 	return &PresenceCache{
@@ -50,6 +56,7 @@ func (p *PresenceCache) SetStats(email string, uplink, downlink int64) {
 	}
 }
 
+// IsOnline возвращает true если пользователь был активен в пределах timeout.
 func (p *PresenceCache) IsOnline(email string) bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
@@ -66,4 +73,27 @@ func (p *PresenceCache) IsOnline(email string) bool {
 
 	// Если давно неактивен — офлайн
 	return false
+}
+
+// GetAllStats возвращает срез UserStats по всем пользователям в кэше.
+//
+// Фронт получает один объект со всеми юзерами — может отрисовать
+// индивидуальные шкалы трафика и при желании агрегировать на своей стороне.
+// Один RLock на весь проход — не держим мьютекс дольше необходимого.
+func (p *PresenceCache) GetAllStats() []models.UserStats {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+ 
+	result := make([]models.UserStats, 0, len(p.state))
+	now := time.Now()
+ 
+	for email, presence := range p.state {
+		result = append(result, models.UserStats{
+			Email:    email,
+			Uplink:   presence.totalUplink,
+			Downlink: presence.totalDownlink,
+			Online:   now.Sub(presence.lastActivity) < p.timeout,
+		})
+	}
+	return result
 }

--- a/internal/models/stats.go
+++ b/internal/models/stats.go
@@ -15,10 +15,13 @@ type StatsProvider interface {
 // UserStats — транспортная структура для передачи живых данных из Xray.
 // Не является моделью БД — тегов gorm здесь нет намеренно.
 // Uplink и Downlink хранятся в байтах (raw от Xray).
+// Используется в ответе GET /api/stats — фронт получает массив,
+// может отрисовать шкалы для каждого юзера и при желании сложить итог сам.
 type UserStats struct {
 	Email    string `json:"email"`
-	Downlink int64  `json:"downlink_bytes"`
 	Uplink   int64  `json:"uplink_bytes"`
+	Downlink int64  `json:"downlink_bytes"`
+	Online   bool   `json:"online"`
 }
 
 // UserHistory — запись в БД, один снимок состояния трафика пользователя.

--- a/internal/xray/stats.go
+++ b/internal/xray/stats.go
@@ -3,6 +3,7 @@ package xray
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -140,6 +141,7 @@ func (c *Client) AddUser(ctx context.Context, user models.User) error {
 		return fmt.Errorf("xray add user %s on inbound %s: %w", user.Email, user.InboundTag, err)
 	}
 
+	slog.Info("XRAY_DEBUG", "email", user.Email, "uuid", user.UUID, "tag", user.InboundTag)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Rework the backend stats path so collector failures can re-provision missing Xray users, while the API serves cached presence snapshots from memory instead of querying Xray directly. This reduces request latency and keeps stats available even if Xray is briefly unavailable.

## Type of Change
- [ ] FEAT: New functionality
- [x] FIX: Bug fix
- [ ] REFACTOR: Code change
- [ ] PERF: Performance improvement
- [ ] BUILD: Changes affecting build system or dependencies

## Verification Results
### Automated Tests
- Unit Tests: NA
- Integration Tests: NA
- Coverage Change: NA

### Manual Verification
Describe the verification procedure and provide evidence (CLI output/Logs).

## Compliance Checklist
- [x] Commits follow Conventional Commits specification.
- [x] Documentation updated.
- [x] No sensitive data included.
- [x] Linear history maintained.