### PR TITLE
feat(dashboard): add error state management and visual indicators

### DIFF
--- a/web/ui/src/app/dashboard/page.tsx
+++ b/web/ui/src/app/dashboard/page.tsx
@@ -61,6 +61,7 @@ export default function DashboardPage() {
     // Экшены
     fetchAll,
     executeAction,
+    hasError,
   } = useDashboard();
 
   return (
@@ -99,25 +100,30 @@ export default function DashboardPage() {
 
             <div className="flex items-center gap-2">
               {/* Индикатор live-обновления */}
-              <div className="flex items-center gap-2 px-3 py-1.5 rounded-full border border-white/8 bg-white/4">
+              <div className="flex items-center gap-2 px-3 py-1.5 rounded-full">
                 <motion.span
-                  className="w-1.5 h-1.5 rounded-full bg-emerald-400"
-                  animate={{ opacity: [1, 0.3, 1] }}
+                  className="w-1.5 h-1.5 rounded-full"
+                  animate={{ 
+                    opacity: [1, 0.5, 1], 
+                    backgroundColor: hasError ? '#ff3b5c' : '#34d399',
+                  }}
                   transition={{ duration: 2, repeat: Infinity }}
                 />
-                <span className="text-[9px] uppercase tracking-[0.2em] text-white/35">
-                  Live · 10s
+                <span className="text-[12px] uppercase tracking-[0.2em] text-white/65">
+                  {hasError ? 'Error' : 'Live · 10s'}
                 </span>
               </div>
 
               {/* Создать пользователя */}
               <motion.button
                 onClick={() => setShowCreate(true)}
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-                className="flex items-center gap-2 px-4 py-2 rounded-xl
+                disabled={hasError}
+                whileHover={hasError ? {} : { scale: 1.02 }}
+                whileTap={hasError ? {} : { scale: 0.98 }}
+                className={`flex items-center gap-2 px-4 py-2 rounded-xl
                   font-jakarta font-black text-[10px] uppercase tracking-[0.2em]
-                  text-black transition-all"
+                  text-black transition-all duration-300
+                  ${hasError ? 'opacity-30 cursor-not-allowed select-none' : ''}`}
                 style={{ background: 'var(--accent)' }}
               >
                 <Plus size={12} />
@@ -125,6 +131,37 @@ export default function DashboardPage() {
               </motion.button>
             </div>
           </motion.div>
+
+          {/* ── Системный баннер ошибки сервера ── */}
+          <AnimatePresence>
+            {hasError && (
+              <motion.div
+                initial={{ opacity: 0, height: 0, marginBottom: 0 }}
+                animate={{ opacity: 1, height: 'auto', marginBottom: 12 }}
+                exit={{ opacity: 0, height: 0, marginBottom: 0 }}
+                transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+                className="overflow-hidden"
+              >
+                <div className="relative rounded-xl border border-[#ff3b5c]/30 bg-black/60 backdrop-blur-md p-4 flex items-center gap-3">
+                  {/* Красное неоновое свечение сзади баннера */}
+                  <div className="absolute inset-0 rounded-xl bg-[#ff3b5c]/2 blur-md pointer-events-none" />
+                  
+                  <div className="w-2 h-2 rounded-full bg-[#ff3b5c] animate-pulse" />
+                  <div className="flex-1">
+                    <h3 className="font-geist-mono font-bold text-[11px] uppercase tracking-[0.15em] text-[#ff3b5c]">
+                      Heimdallr Core Link Interrupted
+                    </h3>
+                    <p className="text-[10px] text-white/40 font-geist-mono mt-0.5">
+                      Backend node unreachable (Status 500/401 or Connection Timeout). Interface entered Read-Only mode.
+                    </p>
+                  </div>
+                  <span className="text-[9px] font-geist-mono uppercase tracking-widest text-white/20 bg-white/5 px-2 py-1 rounded border border-white/5">
+                    RECONNECTING...
+                  </span>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
 
           {/* ── Карточки метрик ── */}
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">

--- a/web/ui/src/components/dashboard/hooks/use-dashboard.ts
+++ b/web/ui/src/components/dashboard/hooks/use-dashboard.ts
@@ -74,6 +74,7 @@ export function useDashboard() {
   const [showCreate,    setShowCreate   ] = useState(false);
   const [filter,        setFilter       ] = useState<UserFilter>('all');
   const [search,        setSearch       ] = useState('');
+  const [hasError,      setHasError     ] = useState(false);
 
   // Рефы для дедупликации нотификаций:
   // не хотим показывать "Dashboard synced" при каждом тике поллинга —
@@ -116,6 +117,8 @@ export function useDashboard() {
       usersRes.status === 'fulfilled' &&
       statsRes.status === 'fulfilled' &&
       histRes.status === 'fulfilled';
+
+    setHasError(!allSuccess);
 
     if (allSuccess) {
       if (!hasAnnouncedSyncRef.current) {
@@ -234,5 +237,6 @@ export function useDashboard() {
     // Экшены
     fetchAll,
     executeAction,
+    hasError,
   };
 }


### PR DESCRIPTION
## Summary

Added comprehensive error handling state to the dashboard. The system now tracks API failures (500/401 status codes or connection timeouts) and enters Read-Only mode with visual feedback.

## Type of Change
- [x] FEAT: New functionality
- [x] REFACTOR: Code change

## Verification Results
### Manual Verification
- Live indicator now changes color from emerald-400 to red (#ff3b5c) on API failure
- "Live" status badge updates to "Error" when backend is unreachable
- Create User button becomes disabled and visually dimmed during errors
- System banner appears with styled error notification and pulsing indicator
- Dashboard remains functional but read-only when backend is down

## Compliance Checklist
- [x] Commits follow Conventional Commits specification.
- [x] Documentation updated.
- [x] No sensitive data included.
- [x] Linear history maintained.