### PR TITLE
chore(api): standardize Next.js public environment variable naming

### DIFF
--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -2,7 +2,7 @@
 // Типизированный клиент к Heimdallr API.
 // Все эндпоинты описаны здесь — компоненты не знают про fetch напрямую.
 
-const API_PORT = process.env.API_PORT || '4000';
+const API_PORT = process.env.NEXT_PUBLIC_API_PORT || '4000';
 const BASE = `http://127.0.0.1:${API_PORT}`;
 
 // ── Types ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Corrected API port configuration to use Next.js public environment variable naming convention. Changed from `API_PORT` to `NEXT_PUBLIC_API_PORT` for proper client-side access.

## Type of Change
- [x] CHORE: Rountine tasks

## Verification Results
### Manual Verification
- API client correctly reads NEXT_PUBLIC_API_PORT from environment
- Falls back to default port 4000 if not defined
- Environment variable is now accessible client-side per Next.js standards

## Compliance Checklist
- [x] Commits follow Conventional Commits specification.
- [x] Documentation updated.
- [x] No sensitive data included.
- [x] Linear history maintained.